### PR TITLE
상품 수정 기능 구현

### DIFF
--- a/src/main/java/com/hyungil/productservice/domain/product/api/ProductApi.java
+++ b/src/main/java/com/hyungil/productservice/domain/product/api/ProductApi.java
@@ -1,6 +1,7 @@
 package com.hyungil.productservice.domain.product.api;
 
 import com.hyungil.productservice.domain.product.dto.request.AddProductRequestDto;
+import com.hyungil.productservice.domain.product.dto.request.UpdateProductRequestDto;
 import com.hyungil.productservice.domain.product.dto.response.GetProductResponseDto;
 import com.hyungil.productservice.domain.product.service.ProductService;
 import javax.validation.Valid;
@@ -8,6 +9,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -31,5 +33,11 @@ public class ProductApi {
 	@ResponseStatus(HttpStatus.OK)
 	public GetProductResponseDto getProduct(@PathVariable Long id) {
 		return productService.getProduct(id);
+	}
+
+	@PutMapping("/{id}")
+	@ResponseStatus(HttpStatus.CREATED)
+	public void updateProduct(@PathVariable Long id, @RequestBody UpdateProductRequestDto updateProductRequestDto) {
+		productService.updateProduct(id, updateProductRequestDto);
 	}
 }

--- a/src/main/java/com/hyungil/productservice/domain/product/domain/entity/Product.java
+++ b/src/main/java/com/hyungil/productservice/domain/product/domain/entity/Product.java
@@ -2,6 +2,7 @@ package com.hyungil.productservice.domain.product.domain.entity;
 
 import com.hyungil.productservice.domain.BaseTimeEntity;
 import com.hyungil.productservice.domain.product.dto.request.AddProductRequestDto;
+import com.hyungil.productservice.domain.product.dto.request.UpdateProductRequestDto;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -33,6 +34,10 @@ public class Product extends BaseTimeEntity {
 		return Product.builder()
 			.productName(addProductRequestDto.getProductName())
 			.build();
+	}
+
+	public void updateProduct(UpdateProductRequestDto updateProductRequestDto) {
+		this.productName = updateProductRequestDto.getProductName();
 	}
 
 }

--- a/src/main/java/com/hyungil/productservice/domain/product/dto/request/UpdateProductRequestDto.java
+++ b/src/main/java/com/hyungil/productservice/domain/product/dto/request/UpdateProductRequestDto.java
@@ -1,20 +1,17 @@
 package com.hyungil.productservice.domain.product.dto.request;
 
-import javax.validation.constraints.NotBlank;
+import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.AccessLevel;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class AddProductRequestDto {
-
-	@NotBlank(message = "잘못된 상품 이름입니다.")
+public class UpdateProductRequestDto {
 	private String productName;
 
 	@Builder
-	public AddProductRequestDto(String productName) {
+	public UpdateProductRequestDto(String productName) {
 		this.productName = productName;
 	}
 }

--- a/src/main/java/com/hyungil/productservice/domain/product/service/ProductService.java
+++ b/src/main/java/com/hyungil/productservice/domain/product/service/ProductService.java
@@ -19,30 +19,38 @@ public class ProductService {
 
 	@Transactional
 	public void addProduct(AddProductRequestDto addProductRequestDto) {
+
 		Product product = Product.from(addProductRequestDto);
+
 		productRepository.save(product);
 	}
 
 	@Transactional(readOnly = true)
 	public GetProductResponseDto getProduct(Long id) {
+
 		Product product = FindByProductId(id);
+
 		return GetProductResponseDto.from(product);
 	}
 
 	@Transactional
 	public void updateProduct(Long id, UpdateProductRequestDto updateProductRequestDto) {
+
 		Product product = FindByProductId(id);
+
 		duplicateProductNameCheck(product, updateProductRequestDto);
+
 		product.updateProduct(updateProductRequestDto);
 	}
 
 	private Product FindByProductId(Long id) {
+
 		return productRepository.findByProductId(id)
 			.orElseThrow(() -> new NotFoundRequestException("존재하지 않는 상품입니다."));
 	}
 
-	private void duplicateProductNameCheck(Product product,
-		UpdateProductRequestDto updateProductRequestDto) {
+	private void duplicateProductNameCheck(Product product, UpdateProductRequestDto updateProductRequestDto) {
+
 		String updateName = updateProductRequestDto.getProductName();
 		String productName = product.getProductName();
 

--- a/src/main/java/com/hyungil/productservice/domain/product/service/ProductService.java
+++ b/src/main/java/com/hyungil/productservice/domain/product/service/ProductService.java
@@ -2,9 +2,11 @@ package com.hyungil.productservice.domain.product.service;
 
 import com.hyungil.productservice.domain.product.dto.request.AddProductRequestDto;
 import com.hyungil.productservice.domain.product.domain.entity.Product;
+import com.hyungil.productservice.domain.product.dto.request.UpdateProductRequestDto;
 import com.hyungil.productservice.domain.product.dto.response.GetProductResponseDto;
 import com.hyungil.productservice.domain.product.repository.ProductRepository;
-import com.hyungil.productservice.global.error.exception.InvalidRequestException;
+import com.hyungil.productservice.global.error.exception.NotFoundRequestException;
+import com.hyungil.productservice.global.error.exception.DuplicateRequestException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -27,8 +29,26 @@ public class ProductService {
 		return GetProductResponseDto.from(product);
 	}
 
+	@Transactional
+	public void updateProduct(Long id, UpdateProductRequestDto updateProductRequestDto) {
+		Product product = FindByProductId(id);
+		duplicateProductNameCheck(product, updateProductRequestDto);
+		product.updateProduct(updateProductRequestDto);
+	}
+
 	private Product FindByProductId(Long id) {
 		return productRepository.findByProductId(id)
-			.orElseThrow(() -> new InvalidRequestException("존재하지 않는 상품입니다."));
+			.orElseThrow(() -> new NotFoundRequestException("존재하지 않는 상품입니다."));
 	}
+
+	private void duplicateProductNameCheck(Product product,
+		UpdateProductRequestDto updateProductRequestDto) {
+		String updateName = updateProductRequestDto.getProductName();
+		String productName = product.getProductName();
+
+		if (productName.equals(updateName)) {
+			throw new DuplicateRequestException("이름을 변경하지 않습니다.");
+		}
+	}
+
 }

--- a/src/main/java/com/hyungil/productservice/global/error/dto/ErrorResponseDto.java
+++ b/src/main/java/com/hyungil/productservice/global/error/dto/ErrorResponseDto.java
@@ -9,18 +9,14 @@ import org.springframework.validation.FieldError;
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class ErrorResponseDto {
 
-	public String message;
-	private static final String INVALID_PARAMS = "invalid params";
+	private String message;
 
 	public static ErrorResponseDto of(final String message) {
 		return new ErrorResponseDto(message);
 	}
 
-	public static ErrorResponseDto of(FieldError fieldError) {
-		if (fieldError == null) {
-			return new ErrorResponseDto(INVALID_PARAMS);
-		} else {
-			return new ErrorResponseDto(fieldError.getDefaultMessage());
-		}
+	public static ErrorResponseDto of(final FieldError fieldError) {
+		return new ErrorResponseDto(fieldError.getDefaultMessage());
 	}
+
 }

--- a/src/main/java/com/hyungil/productservice/global/error/exception/DuplicateRequestException.java
+++ b/src/main/java/com/hyungil/productservice/global/error/exception/DuplicateRequestException.java
@@ -1,0 +1,8 @@
+package com.hyungil.productservice.global.error.exception;
+
+public class DuplicateRequestException extends RuntimeException{
+
+	public DuplicateRequestException(String message) {
+		super(message);
+	}
+}

--- a/src/main/java/com/hyungil/productservice/global/error/exception/InvalidRequestException.java
+++ b/src/main/java/com/hyungil/productservice/global/error/exception/InvalidRequestException.java
@@ -1,9 +1,0 @@
-package com.hyungil.productservice.global.error.exception;
-
-public class InvalidRequestException extends RuntimeException {
-
-	public InvalidRequestException(final String message) {
-		super(message);
-	}
-
-}

--- a/src/main/java/com/hyungil/productservice/global/error/exception/NotFoundRequestException.java
+++ b/src/main/java/com/hyungil/productservice/global/error/exception/NotFoundRequestException.java
@@ -1,0 +1,9 @@
+package com.hyungil.productservice.global.error.exception;
+
+public class NotFoundRequestException extends RuntimeException {
+
+	public NotFoundRequestException(final String message) {
+		super(message);
+	}
+
+}

--- a/src/main/java/com/hyungil/productservice/global/error/handler/ProductExceptionHandler.java
+++ b/src/main/java/com/hyungil/productservice/global/error/handler/ProductExceptionHandler.java
@@ -1,7 +1,8 @@
 package com.hyungil.productservice.global.error.handler;
 
 import com.hyungil.productservice.global.error.dto.ErrorResponseDto;
-import com.hyungil.productservice.global.error.exception.InvalidRequestException;
+import com.hyungil.productservice.global.error.exception.DuplicateRequestException;
+import com.hyungil.productservice.global.error.exception.NotFoundRequestException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.MethodArgumentNotValidException;
@@ -18,16 +19,29 @@ public class ProductExceptionHandler {
 	public ErrorResponseDto handleMethodArgumentNotValidException(
 		MethodArgumentNotValidException exception) {
 
-		log.debug(exception.getBindingResult().getFieldError().getDefaultMessage());
-		return ErrorResponseDto
-			.of(exception.getBindingResult().getFieldError().getDefaultMessage());
+		String message = exception.getBindingResult().getFieldError().getDefaultMessage();
+		log.debug(message);
+
+		return ErrorResponseDto.of(message);
 	}
 
-	@ResponseStatus(HttpStatus.BAD_REQUEST)
-	@ExceptionHandler(InvalidRequestException.class)
-	public ErrorResponseDto handleInvalidRequestException(InvalidRequestException exception) {
+	@ResponseStatus(HttpStatus.NOT_FOUND)
+	@ExceptionHandler(NotFoundRequestException.class)
+	public ErrorResponseDto handleNotFoundException(NotFoundRequestException exception) {
 
-		log.debug(exception.getMessage(), exception);
-		return ErrorResponseDto.of(exception.getMessage());
+		String message = exception.getMessage();
+		log.debug(message, exception);
+
+		return ErrorResponseDto.of(message);
+	}
+
+	@ResponseStatus(HttpStatus.CONFLICT)
+	@ExceptionHandler(DuplicateRequestException.class)
+	public ErrorResponseDto handleDuplicateRequestException(DuplicateRequestException exception) {
+
+		String message = exception.getMessage();
+		log.debug(message, exception);
+
+		return ErrorResponseDto.of(message);
 	}
 }

--- a/src/test/java/com/hyungil/productservice/domain/product/api/ProductApiTest.java
+++ b/src/test/java/com/hyungil/productservice/domain/product/api/ProductApiTest.java
@@ -3,11 +3,14 @@ package com.hyungil.productservice.domain.product.api;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.hyungil.productservice.domain.product.dto.request.AddProductRequestDto;
+import com.hyungil.productservice.domain.product.dto.request.UpdateProductRequestDto;
 import com.hyungil.productservice.domain.product.dto.response.GetProductResponseDto;
+import com.hyungil.productservice.domain.product.repository.ProductRepository;
 import com.hyungil.productservice.domain.product.service.ProductService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
@@ -22,9 +25,11 @@ import org.springframework.web.filter.CharacterEncodingFilter;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.doNothing;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
 
 @WebMvcTest(ProductApi.class)
 @MockBean(JpaMetamodelMappingContext.class)
@@ -51,6 +56,10 @@ class ProductApiTest {
 		.productName("상품")
 		.build();
 
+	UpdateProductRequestDto updateProductRequestDto = UpdateProductRequestDto.builder()
+		.productName("상품상품")
+		.build();
+
 
 	@BeforeEach
 	void beforeEach() {
@@ -74,6 +83,7 @@ class ProductApiTest {
 			.andExpect(status().isCreated());
 	}
 
+
 	@Test
 	@DisplayName("상품 이름에 Null을 등록하여 실패한 경우 Http Status Code 400(BadRequest)를 리턴")
 	void addProductIfNameIsNull() throws Exception {
@@ -87,7 +97,7 @@ class ProductApiTest {
 			.content(toJsonString(addProductRequestDto))
 		)
 			.andExpect(status().isBadRequest())
-			.andExpect(jsonPath("$.message").value("상품 이름은 필수 입력입니다."));
+			.andExpect(jsonPath("$.message").value("잘못된 상품 이름입니다."));
 	}
 
 	@Test
@@ -103,7 +113,7 @@ class ProductApiTest {
 			.content(toJsonString(addProductRequestDto))
 		)
 			.andExpect(status().isBadRequest())
-			.andExpect(jsonPath("$.message").value("상품 이름은 필수 입력입니다."));
+			.andExpect(jsonPath("$.message").value("잘못된 상품 이름입니다."));
 	}
 
 	@Test
@@ -119,7 +129,7 @@ class ProductApiTest {
 			.content(toJsonString(addProductRequestDto))
 		)
 			.andExpect(status().isBadRequest())
-			.andExpect(jsonPath("$.message").value("상품 이름은 필수 입력입니다."));
+			.andExpect(jsonPath("$.message").value("잘못된 상품 이름입니다."));
 	}
 
 	@Test
@@ -138,4 +148,18 @@ class ProductApiTest {
 	private String toJsonString(Object dto) throws JsonProcessingException {
 		return objectMapper.writeValueAsString(dto);
 	}
+
+	@Test
+	@DisplayName("상품 수정에 성공할 경우 Http Status Code 201(Created)를 리턴")
+	void updateProduct() throws Exception {
+
+		doNothing().when(productService).updateProduct(1L, updateProductRequestDto);
+
+		mockMvc.perform(put("/products/1")
+			.contentType(MediaType.APPLICATION_JSON)
+			.content(toJsonString(updateProductRequestDto))
+		)
+			.andExpect(status().isCreated());
+	}
+
 }

--- a/src/test/java/com/hyungil/productservice/domain/product/service/ProductServiceTest.java
+++ b/src/test/java/com/hyungil/productservice/domain/product/service/ProductServiceTest.java
@@ -1,15 +1,20 @@
 package com.hyungil.productservice.domain.product.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.hyungil.productservice.domain.product.domain.entity.Product;
 import com.hyungil.productservice.domain.product.dto.request.AddProductRequestDto;
+import com.hyungil.productservice.domain.product.dto.request.UpdateProductRequestDto;
 import com.hyungil.productservice.domain.product.dto.response.GetProductResponseDto;
 import com.hyungil.productservice.domain.product.repository.ProductRepository;
+import com.hyungil.productservice.global.error.exception.NotFoundRequestException;
 import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -35,9 +40,14 @@ class ProductServiceTest {
 		.productName("상품")
 		.build();
 
+	UpdateProductRequestDto updateProductRequestDto = UpdateProductRequestDto.builder()
+		.productName("변경된 상품")
+		.build();
+
 	@Test
 	@DisplayName("상품 등록에 성공한다.")
 	void addProduct() {
+
 		productService.addProduct(addProductRequestDto);
 
 		verify(productRepository, times(1)).save(any());
@@ -45,11 +55,57 @@ class ProductServiceTest {
 
 	@Test
 	@DisplayName("특정 상품 조회에 성공한다.")
-	void getPerson() {
+	void getProduct() {
+
+		Long id = 1L;
+
 		when(productRepository.findByProductId(1L)).thenReturn(Optional.of(product));
 
-		GetProductResponseDto getProductResponseDto = productService.getProduct(1L);
+		GetProductResponseDto getProductResponseDto = productService.getProduct(id);
 
 		assertThat(getProductResponseDto.getProductName()).isEqualTo("상품");
 	}
+
+	@Test
+	@DisplayName("특정 id를 가진 상품이 존재하지 않아 조회에 실패한다.")
+	void updateIfProductNotFound() {
+
+		Long id = 1L;
+
+		when(productRepository.findByProductId(id)).thenReturn(Optional.empty());
+
+		assertThrows(NotFoundRequestException.class,
+			() -> productService.updateProduct(id, updateProductRequestDto));
+
+		verify(productRepository, times(1)).findByProductId(id);
+	}
+
+	@Test
+	@DisplayName("상품 수정에 성공한다.")
+	void updateProduct() {
+
+		Long id = 1L;
+
+		when(productRepository.findByProductId(id)).thenReturn(Optional.of(product));
+
+		productService.updateProduct(id, updateProductRequestDto);
+
+		assertThat(product.getProductName()).isEqualTo(updateProductRequestDto.getProductName());
+
+		verify(productRepository, atLeastOnce()).findByProductId(1L);
+	}
+
+	@Test
+	@DisplayName("특정 id를 가진 상품이 존재하지 않아 조회에 실패한다.")
+	public void getProductIfNotFound() {
+
+		Long id = 1L;
+
+		given(productRepository.findByProductId(id)).willReturn(Optional.empty());
+
+		assertThrows(NotFoundRequestException.class, () -> productService.getProduct(id));
+
+		verify(productRepository, times(1)).findByProductId(id);
+	}
+
 }


### PR DESCRIPTION
<!--- The issue this PR addresses (이 PR이 다루는 문제) -->
Fixes #?

<!--- Detailed description of the change/feature (변경 / 기능에 대한 자세한 설명) -->
### 상세 내용
상품 수정 기능을 구현하였습니다,
- Controller, Service, Repository Layer TestCode를 작성하였습니다.
- 존재하지 않는 상품 수정시 `존재하지 않는 상품입니다.`를 응답해줄 수 있도록 예외를 전환하였습니다.
- 기존의 상품명과 똑같은 상품명으로 수정을 요청할 시, `이름을 변경하지 않습니다`로 예외를 전환해줌으로써 불필요한  DB I/O를 줄였습니다.