### PR TITLE
전체 상품 목록 조회 기능

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,58 @@
-# msa-product-service
-상품 서비스 API 서버
+# 상품 서비스 API 서버
+
+상품 서비스 HTTP URL : http://localhost:8081
+
+### 디렉토리 구조
+
+```bash
+   ├─ main
+      ├─ kotlin
+         ├─ com.hyungil.productservice
+            ├─ domain                                             - 도메인을 담당하는 디렉토리     
+                ├─ product                           
+                  ├─ api                                          - Controller 같은 경우에는 ModelAndView를 리턴하는 느낌이 있어서 명시적으로 api로 칭함
+                      ├─ ProductApi.java
+                  ├─ domain                                       - 도메인 엔티티에 대한 클래스로 구성
+                      ├─ entity
+                          ├─ Product.java
+                  ├─ dto                                          - Request, Response 객체들로 구성
+                      ├─ request
+                          ├─ AddProductrequestDto.java
+                          ├─ UpdateProductrequestDto.java
+                      ├─ response
+                          ├─ GetProductResponseDto.java
+                          ├─ GetProductsResponseDto.java
+                  ├─ repository                                   - Entity에 의해 생성된 DB에 접근하는 메서드들로 이루어진 클래스로 구성
+                      ├─ ProductRepository.java                   
+                  ├─ service                                      - 비즈니스 로직을 수행                         
+                      ├─ ProductService.java    
+               ├─ model                                           - Domain Entity 객체들이 공통적으로 사용할 객체
+                  ├─ BaseTimeEntity.java
+            
+            ├─ global                                             - 프로젝트에서 전역적으로 사용되는 객체들로 구성
+                ├─ commom                                         - 공통으로 사용되는 Value 객체들로 구성
+                  ├─ util                                         - 유틸성 클래스로 구성
+                    ├─ constants                                  - 공통 상수 관련
+                        ├─ ErrorMessageConstant.java           
+                ├─ error                                          - 예외 핸들링을 담당하는 클래스로 구성
+                  ├─ dto                                          - 예외처리 관련 데이터 교환을 위해 사용
+                      ├─ ErrorResponserDto.java                              
+                  ├─ exception                                    - 예외처리 관련
+                      ├─ DuplicateRequestException.java                                
+                      ├─ NotFoubdRequestException.java                                
+                  ├─ handler                                      - 모든 예외를 한 곳에서 처리하기 위한 클래스로 구성
+                      ├─ ProductExceptionHandler.java                             
+                             
+   ├─ test                                                        -  모든 Layer에 모든 case마다 단위 테스트 작성을 위한 클래스로 구성
+      ├─ java
+         ├─ com.hyungil.productservice.domain.product
+            ├─ api
+              ├─ ProductApiTest.java
+            ├─ repository
+              ├─ ProductRepositoryTest.java
+            ├─ service
+              ├─ ProductServiceTest.java
+                                 
+```
+
+

--- a/src/main/java/com/hyungil/productservice/domain/model/BaseTimeEntity.java
+++ b/src/main/java/com/hyungil/productservice/domain/model/BaseTimeEntity.java
@@ -1,4 +1,4 @@
-package com.hyungil.productservice.domain;
+package com.hyungil.productservice.domain.model;
 
 import java.time.LocalDateTime;
 import javax.persistence.Column;

--- a/src/main/java/com/hyungil/productservice/domain/product/api/ProductApi.java
+++ b/src/main/java/com/hyungil/productservice/domain/product/api/ProductApi.java
@@ -3,9 +3,14 @@ package com.hyungil.productservice.domain.product.api;
 import com.hyungil.productservice.domain.product.dto.request.AddProductRequestDto;
 import com.hyungil.productservice.domain.product.dto.request.UpdateProductRequestDto;
 import com.hyungil.productservice.domain.product.dto.response.GetProductResponseDto;
+import com.hyungil.productservice.domain.product.dto.response.GetProductsResponseDto;
 import com.hyungil.productservice.domain.product.service.ProductService;
+import java.util.List;
 import javax.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -36,15 +41,23 @@ public class ProductApi {
 		return productService.getProduct(id);
 	}
 
+	@GetMapping
+	@ResponseStatus(HttpStatus.OK)
+	public List<GetProductsResponseDto> getProductsByPagination(
+		@PageableDefault(sort = "id", direction = Sort.Direction.DESC) Pageable pageable) {
+		return productService.getProductsByPagination(pageable);
+	}
+
 	@PutMapping("/{id}")
 	@ResponseStatus(HttpStatus.CREATED)
-	public void updateProduct(@PathVariable Long id, @RequestBody UpdateProductRequestDto updateProductRequestDto) {
+	public void updateProduct(@PathVariable Long id,
+		@RequestBody UpdateProductRequestDto updateProductRequestDto) {
 		productService.updateProduct(id, updateProductRequestDto);
 	}
 
 	@ResponseStatus(HttpStatus.OK)
 	@DeleteMapping("/{id}")
-	public void deleteProduct(@PathVariable Long id){
+	public void deleteProduct(@PathVariable Long id) {
 		productService.deleteProduct(id);
 	}
 }

--- a/src/main/java/com/hyungil/productservice/domain/product/domain/entity/Product.java
+++ b/src/main/java/com/hyungil/productservice/domain/product/domain/entity/Product.java
@@ -20,13 +20,13 @@ public class Product extends BaseTimeEntity {
 
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
-	private Long productId;
+	private Long id;
 
 	private String productName;
 
 	@Builder
-	private Product(Long productId, String productName) {
-		this.productId = productId;
+	private Product(Long id, String productName) {
+		this.id = id;
 		this.productName = productName;
 	}
 

--- a/src/main/java/com/hyungil/productservice/domain/product/domain/entity/Product.java
+++ b/src/main/java/com/hyungil/productservice/domain/product/domain/entity/Product.java
@@ -1,6 +1,6 @@
 package com.hyungil.productservice.domain.product.domain.entity;
 
-import com.hyungil.productservice.domain.BaseTimeEntity;
+import com.hyungil.productservice.domain.model.BaseTimeEntity;
 import com.hyungil.productservice.domain.product.dto.request.AddProductRequestDto;
 import com.hyungil.productservice.domain.product.dto.request.UpdateProductRequestDto;
 import lombok.AccessLevel;

--- a/src/main/java/com/hyungil/productservice/domain/product/dto/response/GetProductResponseDto.java
+++ b/src/main/java/com/hyungil/productservice/domain/product/dto/response/GetProductResponseDto.java
@@ -9,6 +9,7 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class GetProductResponseDto {
+
     private String productName;
 
     @Builder

--- a/src/main/java/com/hyungil/productservice/domain/product/dto/response/GetProductsResponseDto.java
+++ b/src/main/java/com/hyungil/productservice/domain/product/dto/response/GetProductsResponseDto.java
@@ -1,0 +1,29 @@
+package com.hyungil.productservice.domain.product.dto.response;
+
+import com.hyungil.productservice.domain.product.domain.entity.Product;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class GetProductsResponseDto {
+
+	private Long productId;
+	private String productName;
+
+	@Builder
+	public GetProductsResponseDto(Long productId, String productName){
+		this.productId = productId;
+		this.productName = productName;
+	}
+
+	public static GetProductsResponseDto from(Product product) {
+		return GetProductsResponseDto.builder()
+			.productId(product.getId())
+			.productName(product.getProductName())
+			.build();
+	}
+
+}

--- a/src/main/java/com/hyungil/productservice/domain/product/repository/ProductRepository.java
+++ b/src/main/java/com/hyungil/productservice/domain/product/repository/ProductRepository.java
@@ -8,5 +8,6 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface ProductRepository extends JpaRepository<Product, Long> {
 
-	Optional<Product> findByProductId(Long id);
+	Optional<Product> findById(Long id);
+
 }

--- a/src/main/java/com/hyungil/productservice/domain/product/service/ProductService.java
+++ b/src/main/java/com/hyungil/productservice/domain/product/service/ProductService.java
@@ -7,10 +7,16 @@ import com.hyungil.productservice.domain.product.dto.request.AddProductRequestDt
 import com.hyungil.productservice.domain.product.domain.entity.Product;
 import com.hyungil.productservice.domain.product.dto.request.UpdateProductRequestDto;
 import com.hyungil.productservice.domain.product.dto.response.GetProductResponseDto;
+import com.hyungil.productservice.domain.product.dto.response.GetProductsResponseDto;
 import com.hyungil.productservice.domain.product.repository.ProductRepository;
 import com.hyungil.productservice.global.error.exception.NotFoundRequestException;
 import com.hyungil.productservice.global.error.exception.DuplicateRequestException;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.util.Streamable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -36,6 +42,16 @@ public class ProductService {
 		return GetProductResponseDto.from(product);
 	}
 
+	@Transactional(readOnly = true)
+	public List<GetProductsResponseDto> getProductsByPagination(Pageable pageable) {
+
+		return Stream.of(productRepository.findAll(pageable))
+			.flatMap(Streamable::stream)
+			.map(GetProductsResponseDto::from)
+			.collect(Collectors.toList());
+	}
+
+
 	@Transactional
 	public void updateProduct(Long id, UpdateProductRequestDto updateProductRequestDto) {
 
@@ -56,11 +72,12 @@ public class ProductService {
 
 	private Product FindByProductId(Long id) {
 
-		return productRepository.findByProductId(id)
+		return productRepository.findById(id)
 			.orElseThrow(() -> new NotFoundRequestException(NOT_FOUND_PRODUCT));
 	}
 
-	private void duplicateProductNameCheck(Product product, UpdateProductRequestDto updateProductRequestDto) {
+	private void duplicateProductNameCheck(Product product,
+		UpdateProductRequestDto updateProductRequestDto) {
 
 		String updateName = updateProductRequestDto.getProductName();
 		String productName = product.getProductName();

--- a/src/main/java/com/hyungil/productservice/global/error/handler/GlobalExceptionHandler.java
+++ b/src/main/java/com/hyungil/productservice/global/error/handler/GlobalExceptionHandler.java
@@ -12,7 +12,7 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 @Slf4j
 @RestControllerAdvice
-public class ProductExceptionHandler {
+public class GlobalExceptionHandler {
 
 	@ExceptionHandler(MethodArgumentNotValidException.class)
 	@ResponseStatus(HttpStatus.BAD_REQUEST)

--- a/src/test/java/com/hyungil/productservice/domain/product/api/ProductApiTest.java
+++ b/src/test/java/com/hyungil/productservice/domain/product/api/ProductApiTest.java
@@ -7,7 +7,6 @@ import com.hyungil.productservice.domain.product.dto.request.UpdateProductReques
 import com.hyungil.productservice.domain.product.dto.response.GetProductResponseDto;
 import com.hyungil.productservice.domain.product.repository.ProductRepository;
 import com.hyungil.productservice.domain.product.service.ProductService;
-import com.hyungil.productservice.global.error.exception.DuplicateRequestException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -17,16 +16,16 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
-import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.context.WebApplicationContext;
 import org.springframework.web.filter.CharacterEncodingFilter;
 
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.doNothing;
-import static org.mockito.Mockito.doThrow;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -141,15 +140,22 @@ class ProductApiTest {
 
 		given(productService.getProduct(1L)).willReturn(getProductResponseDto);
 
-		mockMvc.perform(MockMvcRequestBuilders.get("/products/1")
+		mockMvc.perform(get("/products/1")
 			.contentType(MediaType.APPLICATION_JSON)
 		)
 			.andExpect(status().isOk())
 			.andExpect(jsonPath("$.productName").value("상품"));
 	}
 
-	private String toJsonString(Object dto) throws JsonProcessingException {
-		return objectMapper.writeValueAsString(dto);
+	@Test
+	@DisplayName("전체 상품 조회 성공시 Http Status Code 200(Ok) 반환")
+	void getProductsByPagination() throws Exception {
+		mockMvc.perform(get("/products")
+			.param("page", "1")
+			.param("size", "2")
+			.contentType(MediaType.APPLICATION_JSON))
+
+			.andExpect(status().isOk());
 	}
 
 	@Test
@@ -171,12 +177,15 @@ class ProductApiTest {
 
 		doNothing().when(productService).deleteProduct(1L);
 
-		mockMvc.perform(
-			MockMvcRequestBuilders.delete("/products/{id}", 1)
-				.contentType(MediaType.APPLICATION_JSON)
+		mockMvc.perform(delete("/products/{id}", 1)
+			.contentType(MediaType.APPLICATION_JSON)
 		)
 			.andExpect(status().isOk());
 
+	}
+
+	private String toJsonString(Object dto) throws JsonProcessingException {
+		return objectMapper.writeValueAsString(dto);
 	}
 
 }

--- a/src/test/java/com/hyungil/productservice/domain/product/repository/ProductRepositoryTest.java
+++ b/src/test/java/com/hyungil/productservice/domain/product/repository/ProductRepositoryTest.java
@@ -3,11 +3,10 @@ package com.hyungil.productservice.domain.product.repository;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
 
 import com.hyungil.productservice.domain.product.domain.entity.Product;
+import java.util.List;
 import java.util.Optional;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -38,7 +37,7 @@ class ProductRepositoryTest {
 
 		productRepository.save(product);
 
-		Product saveProduct = productRepository.findByProductId(product.getProductId()).get();
+		Product saveProduct = productRepository.findById(product.getId()).get();
 
 		assertThat(product).isEqualTo(saveProduct);
 	}
@@ -61,7 +60,7 @@ class ProductRepositoryTest {
 		Product savedProduct = productRepository.save(product);
 
 		Optional<Product> productFindByName = productRepository
-			.findByProductId(product.getProductId());
+			.findById(product.getId());
 
 		productFindByName.ifPresent(
 			value -> assertEquals(savedProduct.getProductName(), value.getProductName()));
@@ -71,7 +70,7 @@ class ProductRepositoryTest {
 	@DisplayName("상품 엔티티의 아이디로 검색해서 데이터베이스에서 상품 가져오기 실패")
 	public void findByProductIdFailureTest() {
 
-		Optional<Product> productFindByName = productRepository.findByProductId(1L);
+		Optional<Product> productFindByName = productRepository.findById(1L);
 
 		assertEquals(Optional.empty(), productFindByName);
 	}
@@ -88,7 +87,7 @@ class ProductRepositoryTest {
 			assertNotNull(e);
 		}
 
-		Optional<Product> deletedProduct = productRepository.findByProductId(1L);
+		Optional<Product> deletedProduct = productRepository.findById(1L);
 
 		assertThat(deletedProduct).isEmpty();
 	}
@@ -103,6 +102,21 @@ class ProductRepositoryTest {
 			assertNotNull(e);
 		}
 
+	}
+
+	@Test
+	@DisplayName("데이터베이스에서 상품 테이블의 모든 데이터 가져오기")
+	public void findAll() {
+
+		Product product = Product.builder().productName("상품").build();
+		Product product2 = Product.builder().productName("상품2").build();
+
+		productRepository.save(product);
+		productRepository.save(product2);
+
+		List<Product> result = productRepository.findAll();
+
+		assertThat(result.size()).isEqualTo(2);
 	}
 
 }


### PR DESCRIPTION
<!--- The issue this PR addresses (이 PR이 다루는 문제) -->
Fixes #11

<!--- Detailed description of the change/feature (변경 / 기능에 대한 자세한 설명) -->
### 상세 내용
- 전체 상품 조회 기능을 추가하였습니다.
     - 전체 상품 조회시 JPA의 Pageable 구현체를 쿼리 메서드의 파라미터로 전달함으로써 쿼리에 페이징을 동적으로 추가하여 pagenation 작업을 완료하였습니다.
     - Controller, Service, Repository Layer TestCode를 작성하였습니다.
     - domain 디렉토리에 model 패키지를 생성하고 이 패키지에 Domain Entity 객체들이 공통적으로 사용할 객체인 BaseTimeEntity 클래스의 위치를 이동하였습니다.
      