### PR TITLE
API 문서화를 위해 RestDocs 적용

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,14 @@
 
 상품 서비스 HTTP URL : http://localhost:8081
 
+### Rest Docs를 사용하여 API문서를 자동화 하였습니다.
+
+[API 문서 보기](HyungilJung.github.io)
+
+### 자세한 사항은 Pull Request를 참고해주시면 감사하겠습니다.
+
+[진행 과정](https://github.com/hyungil-msa-project-university/msa-product-service/pulls?q=is%3Apr+is%3Aclosed)
+
 ### 디렉토리 구조
 
 ```bash

--- a/pom.xml
+++ b/pom.xml
@@ -74,6 +74,7 @@
 
   </dependencies>
 
+
   <build>
     <plugins>
       <plugin>
@@ -105,6 +106,12 @@
       </plugin>
 
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <version>2.21.0</version>
+      </plugin>
+
+      <plugin>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-maven-plugin</artifactId>
         <configuration>
@@ -117,6 +124,7 @@
         </configuration>
       </plugin>
     </plugins>
+
   </build>
 
 </project>

--- a/src/main/asciidoc/api-guide.adoc
+++ b/src/main/asciidoc/api-guide.adoc
@@ -1,0 +1,190 @@
+= Product API Docs
+Junghyungile<junghyungile@gmail.com>
+:doctype: book
+:icons: font
+:source-highlighter: highlightjs
+:toc: left
+:toclevels: 4
+:sectlinks:
+:operation-curl-request-title: Example request
+:operation-http-response-title: Example response
+
+[[overview_http_verbs]]
+== HTTP Methods
+
+클라이언트와 서버 사이에 이루어지는 요청(Request)과 응답(Response) 데이터를 전송하는 방식입니다.
+
+|===
+| Method | Content
+
+| `GET`
+| 요청받은 URI의 정보를 검색하여 응답합니다.
+
+| `POST`
+| 요청된 자원을 생성(CREATE) 합니다.
+
+| `PUT`
+| 요청된 자원을 수정(UPDATE)한다. 리소스의 모든 것을 업데이트 합니다..
+
+| `PATCH`
+| PUT과 유사하게 요청된 자원을 수정(UPATE) 할 때 사용한다. 리소스의 일부를 업데이트 합니다.
+
+| `DELETE`
+| 요청된 자원을 삭제할 것을 요청합니다.
+|===
+
+[[overview_http_status_codes]]
+== HTTP status codes
+
+모든 HTTP 응답 코드는 5개의 클래스(분류)로 구분된다. 상태 코드의 첫 번째 숫자는 응답의 클래스를 정의한다. 첫자리에 대한 5가지 값들은 다음과 같습니다:
+
+1xx (정보): 요청을 받았으며 프로세스를 계속합니다.
+
+2xx (성공): 요청을 성공적으로 받았으며 인식했고 수용합니다.
+
+3xx (리다이렉션): 요청 완료를 위해 추가 작업 조치가 필요합니다.
+
+4xx (클라이언트 오류): 요청의 문법이 잘못되었거나 요청을 처리할 수 없습니다.
+
+5xx (서버 오류): 서버가 명백히 유효한 요청에 대해 충족을 실패습니다.
+
+|===
+| Status code | Usage
+
+| `200 OK`
+| 요청이 성공적으로 되었습니다.
+
+| `201 Created`
+| 요청이 성공적이었으며 그 결과로 새로운 리소스가 생성되었습니다. 이 응답은 일반적으로 POST 요청 또는 일부 PUT 요청 이후에 따라옵니다.
+
+| `400 Bad Request`
+| 이 응답은 잘못된 문법으로 인하여 서버가 요청을 이해할 수 없음을 의미합니다.
+
+| `404 NotFoundException`
+| 클라이언트의 요청에 관해 서버가 요청받은 리소스를 찾을 수 없다는 것을 의미합니다.
+
+| `409 Conflict`
+| 서버가 요청을 수행하는 중에 충돌이 발생했습니다. 서버는 응답할 때 충돌에 대한 정보를 포함해야 합니다.
+|===
+
+== Product API
+
+== ● 상품 등록
+
+=== 1-1 상품 등록에 성공할 경우 Http Status Code 201(Created)를 리턴
+
+**curl**
+include::{snippets}/products/create/successful/curl-request.adoc[]
+
+**요청 필드**
+include::{snippets}/products/create/successful/request-fields.adoc[]
+
+**요청 예시**
+include::{snippets}/products/create/successful/http-request.adoc[]
+
+**응답 예시**
+include::{snippets}/products/create/successful/http-response.adoc[]
+
+=== 1-2 상품 이름에 Null을 등록하여 실패한 경우 Http Status Code 400(BadRequest)를 리턴
+
+**curl**
+include::{snippets}/products/null/fail/curl-request.adoc[]
+
+**요청 필드**
+include::{snippets}/products/null/fail/request-fields.adoc[]
+
+**요청 예시**
+include::{snippets}/products/null/fail/http-request.adoc[]
+
+**응답 예시**
+include::{snippets}/products/null/fail/http-response.adoc[]
+
+=== 1-3 상품 이름에 null이나 빈 값 또는 공 백을 등록하여 실패한 경우 Http Status Code 400(BadRequest)를 리턴
+
+**curl**
+include::{snippets}/products/emptu/fail/curl-request.adoc[]
+
+**요청 필드**
+include::{snippets}/products/emptu/fail/request-fields.adoc[]
+
+**요청 예시**
+include::{snippets}/products/emptu/fail/http-request.adoc[]
+
+**응답 예시**
+include::{snippets}/products/emptu/fail/http-response.adoc[]
+
+=== 1-4 상품 이름에 null이나 공백을 등록하여 실패한 경우 Http Status Code 400(BadRequest)를 리턴
+
+**curl**
+include::{snippets}/products/blank/fail/curl-request.adoc[]
+
+**요청 필드**
+include::{snippets}/products/blank/fail/request-fields.adoc[]
+
+**요청 예시**
+include::{snippets}/products/blank/fail/http-request.adoc[]
+
+**응답 예시**
+include::{snippets}/products/blank/fail/http-response.adoc[]
+
+== ● 상품 조회
+
+=== 1-1 특정 상품 조회에 성공할 경우 Http Status Code 201(Created)를 리턴
+
+**curl**
+include::{snippets}/products/get/successful/curl-request.adoc[]
+
+**요청 예시**
+include::{snippets}/products/get/successful/http-request.adoc[]
+
+**응답 필드**
+include::{snippets}/products/get/successful/response-fields.adoc[]
+
+**응답 예시**
+include::{snippets}/products/get/successful/http-response.adoc[]
+
+=== 1-2 전체 상품 조회에 성공할 경우 Http Status Code 201(Created)를 리턴
+
+**curl**
+include::{snippets}/products/all/get/successful/curl-request.adoc[]
+
+**요청 예시**
+include::{snippets}/products/all/get/successful/http-request.adoc[]
+
+**응답 필드**
+include::{snippets}/products/all/get/successful/response-fields.adoc[]
+
+**응답 예시**
+include::{snippets}/products/all/get/successful/http-response.adoc[]
+
+== ● 상품 수정
+
+=== 1-1 상품 수정에 성공할 경우 Http Status Code 201(Created)를 리턴
+
+**curl**
+include::{snippets}/products/update/successful/curl-request.adoc[]
+
+**path-parameters**
+include::{snippets}/products/update/successful/path-parameters.adoc[]
+
+**요청 예시**
+include::{snippets}/products/update/successful/http-request.adoc[]
+
+**응답 예시**
+include::{snippets}/products/update/successful/http-response.adoc[]
+
+== ● 상품 삭제
+
+=== 1-1 상품 삭제에 성공할 경우 Http Status Code 201(Created)를 리턴
+
+**curl**
+include::{snippets}/products/delete/successful/curl-request.adoc[]
+
+**path-parameters**
+include::{snippets}/products/delete/successful/path-parameters.adoc[]
+
+**요청 예시**
+include::{snippets}/products/delete/successful/http-request.adoc[]
+
+**응답 예시**
+include::{snippets}/products/delete/successful/http-response.adoc[]

--- a/src/main/asciidoc/api-guide.html
+++ b/src/main/asciidoc/api-guide.html
@@ -1,0 +1,1117 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<!--[if IE]><meta http-equiv="X-UA-Compatible" content="IE=edge"><![endif]-->
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<meta name="generator" content="Asciidoctor 1.5.8">
+<meta name="author" content="Junghyungile&lt;junghyungile@gmail.com&gt;">
+<title>Product API Docs</title>
+<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Open+Sans:300,300italic,400,400italic,600,600italic%7CNoto+Serif:400,400italic,700,700italic%7CDroid+Sans+Mono:400,700">
+<style>
+/* Asciidoctor default stylesheet | MIT License | http://asciidoctor.org */
+/* Uncomment @import statement below to use as custom stylesheet */
+/*@import "https://fonts.googleapis.com/css?family=Open+Sans:300,300italic,400,400italic,600,600italic%7CNoto+Serif:400,400italic,700,700italic%7CDroid+Sans+Mono:400,700";*/
+article,aside,details,figcaption,figure,footer,header,hgroup,main,nav,section,summary{display:block}
+audio,canvas,video{display:inline-block}
+audio:not([controls]){display:none;height:0}
+script{display:none!important}
+html{font-family:sans-serif;-ms-text-size-adjust:100%;-webkit-text-size-adjust:100%}
+a{background:transparent}
+a:focus{outline:thin dotted}
+a:active,a:hover{outline:0}
+h1{font-size:2em;margin:.67em 0}
+abbr[title]{border-bottom:1px dotted}
+b,strong{font-weight:bold}
+dfn{font-style:italic}
+hr{-moz-box-sizing:content-box;box-sizing:content-box;height:0}
+mark{background:#ff0;color:#000}
+code,kbd,pre,samp{font-family:monospace;font-size:1em}
+pre{white-space:pre-wrap}
+q{quotes:"\201C" "\201D" "\2018" "\2019"}
+small{font-size:80%}
+sub,sup{font-size:75%;line-height:0;position:relative;vertical-align:baseline}
+sup{top:-.5em}
+sub{bottom:-.25em}
+img{border:0}
+svg:not(:root){overflow:hidden}
+figure{margin:0}
+fieldset{border:1px solid silver;margin:0 2px;padding:.35em .625em .75em}
+legend{border:0;padding:0}
+button,input,select,textarea{font-family:inherit;font-size:100%;margin:0}
+button,input{line-height:normal}
+button,select{text-transform:none}
+button,html input[type="button"],input[type="reset"],input[type="submit"]{-webkit-appearance:button;cursor:pointer}
+button[disabled],html input[disabled]{cursor:default}
+input[type="checkbox"],input[type="radio"]{box-sizing:border-box;padding:0}
+button::-moz-focus-inner,input::-moz-focus-inner{border:0;padding:0}
+textarea{overflow:auto;vertical-align:top}
+table{border-collapse:collapse;border-spacing:0}
+*,*::before,*::after{-moz-box-sizing:border-box;-webkit-box-sizing:border-box;box-sizing:border-box}
+html,body{font-size:100%}
+body{background:#fff;color:rgba(0,0,0,.8);padding:0;margin:0;font-family:"Noto Serif","DejaVu Serif",serif;font-weight:400;font-style:normal;line-height:1;position:relative;cursor:auto;tab-size:4;-moz-osx-font-smoothing:grayscale;-webkit-font-smoothing:antialiased}
+a:hover{cursor:pointer}
+img,object,embed{max-width:100%;height:auto}
+object,embed{height:100%}
+img{-ms-interpolation-mode:bicubic}
+.left{float:left!important}
+.right{float:right!important}
+.text-left{text-align:left!important}
+.text-right{text-align:right!important}
+.text-center{text-align:center!important}
+.text-justify{text-align:justify!important}
+.hide{display:none}
+img,object,svg{display:inline-block;vertical-align:middle}
+textarea{height:auto;min-height:50px}
+select{width:100%}
+.center{margin-left:auto;margin-right:auto}
+.stretch{width:100%}
+.subheader,.admonitionblock td.content>.title,.audioblock>.title,.exampleblock>.title,.imageblock>.title,.listingblock>.title,.literalblock>.title,.stemblock>.title,.openblock>.title,.paragraph>.title,.quoteblock>.title,table.tableblock>.title,.verseblock>.title,.videoblock>.title,.dlist>.title,.olist>.title,.ulist>.title,.qlist>.title,.hdlist>.title{line-height:1.45;color:#7a2518;font-weight:400;margin-top:0;margin-bottom:.25em}
+div,dl,dt,dd,ul,ol,li,h1,h2,h3,#toctitle,.sidebarblock>.content>.title,h4,h5,h6,pre,form,p,blockquote,th,td{margin:0;padding:0;direction:ltr}
+a{color:#2156a5;text-decoration:underline;line-height:inherit}
+a:hover,a:focus{color:#1d4b8f}
+a img{border:none}
+p{font-family:inherit;font-weight:400;font-size:1em;line-height:1.6;margin-bottom:1.25em;text-rendering:optimizeLegibility}
+p aside{font-size:.875em;line-height:1.35;font-style:italic}
+h1,h2,h3,#toctitle,.sidebarblock>.content>.title,h4,h5,h6{font-family:"Open Sans","DejaVu Sans",sans-serif;font-weight:300;font-style:normal;color:#ba3925;text-rendering:optimizeLegibility;margin-top:1em;margin-bottom:.5em;line-height:1.0125em}
+h1 small,h2 small,h3 small,#toctitle small,.sidebarblock>.content>.title small,h4 small,h5 small,h6 small{font-size:60%;color:#e99b8f;line-height:0}
+h1{font-size:2.125em}
+h2{font-size:1.6875em}
+h3,#toctitle,.sidebarblock>.content>.title{font-size:1.375em}
+h4,h5{font-size:1.125em}
+h6{font-size:1em}
+hr{border:solid #dddddf;border-width:1px 0 0;clear:both;margin:1.25em 0 1.1875em;height:0}
+em,i{font-style:italic;line-height:inherit}
+strong,b{font-weight:bold;line-height:inherit}
+small{font-size:60%;line-height:inherit}
+code{font-family:"Droid Sans Mono","DejaVu Sans Mono",monospace;font-weight:400;color:rgba(0,0,0,.9)}
+ul,ol,dl{font-size:1em;line-height:1.6;margin-bottom:1.25em;list-style-position:outside;font-family:inherit}
+ul,ol{margin-left:1.5em}
+ul li ul,ul li ol{margin-left:1.25em;margin-bottom:0;font-size:1em}
+ul.square li ul,ul.circle li ul,ul.disc li ul{list-style:inherit}
+ul.square{list-style-type:square}
+ul.circle{list-style-type:circle}
+ul.disc{list-style-type:disc}
+ol li ul,ol li ol{margin-left:1.25em;margin-bottom:0}
+dl dt{margin-bottom:.3125em;font-weight:bold}
+dl dd{margin-bottom:1.25em}
+abbr,acronym{text-transform:uppercase;font-size:90%;color:rgba(0,0,0,.8);border-bottom:1px dotted #ddd;cursor:help}
+abbr{text-transform:none}
+blockquote{margin:0 0 1.25em;padding:.5625em 1.25em 0 1.1875em;border-left:1px solid #ddd}
+blockquote cite{display:block;font-size:.9375em;color:rgba(0,0,0,.6)}
+blockquote cite::before{content:"\2014 \0020"}
+blockquote cite a,blockquote cite a:visited{color:rgba(0,0,0,.6)}
+blockquote,blockquote p{line-height:1.6;color:rgba(0,0,0,.85)}
+@media screen and (min-width:768px){h1,h2,h3,#toctitle,.sidebarblock>.content>.title,h4,h5,h6{line-height:1.2}
+h1{font-size:2.75em}
+h2{font-size:2.3125em}
+h3,#toctitle,.sidebarblock>.content>.title{font-size:1.6875em}
+h4{font-size:1.4375em}}
+table{background:#fff;margin-bottom:1.25em;border:solid 1px #dedede}
+table thead,table tfoot{background:#f7f8f7}
+table thead tr th,table thead tr td,table tfoot tr th,table tfoot tr td{padding:.5em .625em .625em;font-size:inherit;color:rgba(0,0,0,.8);text-align:left}
+table tr th,table tr td{padding:.5625em .625em;font-size:inherit;color:rgba(0,0,0,.8)}
+table tr.even,table tr.alt,table tr:nth-of-type(even){background:#f8f8f7}
+table thead tr th,table tfoot tr th,table tbody tr td,table tr td,table tfoot tr td{display:table-cell;line-height:1.6}
+h1,h2,h3,#toctitle,.sidebarblock>.content>.title,h4,h5,h6{line-height:1.2;word-spacing:-.05em}
+h1 strong,h2 strong,h3 strong,#toctitle strong,.sidebarblock>.content>.title strong,h4 strong,h5 strong,h6 strong{font-weight:400}
+.clearfix::before,.clearfix::after,.float-group::before,.float-group::after{content:" ";display:table}
+.clearfix::after,.float-group::after{clear:both}
+*:not(pre)>code{font-size:.9375em;font-style:normal!important;letter-spacing:0;padding:.1em .5ex;word-spacing:-.15em;background-color:#f7f7f8;-webkit-border-radius:4px;border-radius:4px;line-height:1.45;text-rendering:optimizeSpeed;word-wrap:break-word}
+*:not(pre)>code.nobreak{word-wrap:normal}
+*:not(pre)>code.nowrap{white-space:nowrap}
+pre,pre>code{line-height:1.45;color:rgba(0,0,0,.9);font-family:"Droid Sans Mono","DejaVu Sans Mono",monospace;font-weight:400;text-rendering:optimizeSpeed}
+em em{font-style:normal}
+strong strong{font-weight:400}
+.keyseq{color:rgba(51,51,51,.8)}
+kbd{font-family:"Droid Sans Mono","DejaVu Sans Mono",monospace;display:inline-block;color:rgba(0,0,0,.8);font-size:.65em;line-height:1.45;background-color:#f7f7f7;border:1px solid #ccc;-webkit-border-radius:3px;border-radius:3px;-webkit-box-shadow:0 1px 0 rgba(0,0,0,.2),0 0 0 .1em white inset;box-shadow:0 1px 0 rgba(0,0,0,.2),0 0 0 .1em #fff inset;margin:0 .15em;padding:.2em .5em;vertical-align:middle;position:relative;top:-.1em;white-space:nowrap}
+.keyseq kbd:first-child{margin-left:0}
+.keyseq kbd:last-child{margin-right:0}
+.menuseq,.menuref{color:#000}
+.menuseq b:not(.caret),.menuref{font-weight:inherit}
+.menuseq{word-spacing:-.02em}
+.menuseq b.caret{font-size:1.25em;line-height:.8}
+.menuseq i.caret{font-weight:bold;text-align:center;width:.45em}
+b.button::before,b.button::after{position:relative;top:-1px;font-weight:400}
+b.button::before{content:"[";padding:0 3px 0 2px}
+b.button::after{content:"]";padding:0 2px 0 3px}
+p a>code:hover{color:rgba(0,0,0,.9)}
+#header,#content,#footnotes,#footer{width:100%;margin-left:auto;margin-right:auto;margin-top:0;margin-bottom:0;max-width:62.5em;*zoom:1;position:relative;padding-left:.9375em;padding-right:.9375em}
+#header::before,#header::after,#content::before,#content::after,#footnotes::before,#footnotes::after,#footer::before,#footer::after{content:" ";display:table}
+#header::after,#content::after,#footnotes::after,#footer::after{clear:both}
+#content{margin-top:1.25em}
+#content::before{content:none}
+#header>h1:first-child{color:rgba(0,0,0,.85);margin-top:2.25rem;margin-bottom:0}
+#header>h1:first-child+#toc{margin-top:8px;border-top:1px solid #dddddf}
+#header>h1:only-child,body.toc2 #header>h1:nth-last-child(2){border-bottom:1px solid #dddddf;padding-bottom:8px}
+#header .details{border-bottom:1px solid #dddddf;line-height:1.45;padding-top:.25em;padding-bottom:.25em;padding-left:.25em;color:rgba(0,0,0,.6);display:-ms-flexbox;display:-webkit-flex;display:flex;-ms-flex-flow:row wrap;-webkit-flex-flow:row wrap;flex-flow:row wrap}
+#header .details span:first-child{margin-left:-.125em}
+#header .details span.email a{color:rgba(0,0,0,.85)}
+#header .details br{display:none}
+#header .details br+span::before{content:"\00a0\2013\00a0"}
+#header .details br+span.author::before{content:"\00a0\22c5\00a0";color:rgba(0,0,0,.85)}
+#header .details br+span#revremark::before{content:"\00a0|\00a0"}
+#header #revnumber{text-transform:capitalize}
+#header #revnumber::after{content:"\00a0"}
+#content>h1:first-child:not([class]){color:rgba(0,0,0,.85);border-bottom:1px solid #dddddf;padding-bottom:8px;margin-top:0;padding-top:1rem;margin-bottom:1.25rem}
+#toc{border-bottom:1px solid #e7e7e9;padding-bottom:.5em}
+#toc>ul{margin-left:.125em}
+#toc ul.sectlevel0>li>a{font-style:italic}
+#toc ul.sectlevel0 ul.sectlevel1{margin:.5em 0}
+#toc ul{font-family:"Open Sans","DejaVu Sans",sans-serif;list-style-type:none}
+#toc li{line-height:1.3334;margin-top:.3334em}
+#toc a{text-decoration:none}
+#toc a:active{text-decoration:underline}
+#toctitle{color:#7a2518;font-size:1.2em}
+@media screen and (min-width:768px){#toctitle{font-size:1.375em}
+body.toc2{padding-left:15em;padding-right:0}
+#toc.toc2{margin-top:0!important;background-color:#f8f8f7;position:fixed;width:15em;left:0;top:0;border-right:1px solid #e7e7e9;border-top-width:0!important;border-bottom-width:0!important;z-index:1000;padding:1.25em 1em;height:100%;overflow:auto}
+#toc.toc2 #toctitle{margin-top:0;margin-bottom:.8rem;font-size:1.2em}
+#toc.toc2>ul{font-size:.9em;margin-bottom:0}
+#toc.toc2 ul ul{margin-left:0;padding-left:1em}
+#toc.toc2 ul.sectlevel0 ul.sectlevel1{padding-left:0;margin-top:.5em;margin-bottom:.5em}
+body.toc2.toc-right{padding-left:0;padding-right:15em}
+body.toc2.toc-right #toc.toc2{border-right-width:0;border-left:1px solid #e7e7e9;left:auto;right:0}}
+@media screen and (min-width:1280px){body.toc2{padding-left:20em;padding-right:0}
+#toc.toc2{width:20em}
+#toc.toc2 #toctitle{font-size:1.375em}
+#toc.toc2>ul{font-size:.95em}
+#toc.toc2 ul ul{padding-left:1.25em}
+body.toc2.toc-right{padding-left:0;padding-right:20em}}
+#content #toc{border-style:solid;border-width:1px;border-color:#e0e0dc;margin-bottom:1.25em;padding:1.25em;background:#f8f8f7;-webkit-border-radius:4px;border-radius:4px}
+#content #toc>:first-child{margin-top:0}
+#content #toc>:last-child{margin-bottom:0}
+#footer{max-width:100%;background-color:rgba(0,0,0,.8);padding:1.25em}
+#footer-text{color:rgba(255,255,255,.8);line-height:1.44}
+#content{margin-bottom:.625em}
+.sect1{padding-bottom:.625em}
+@media screen and (min-width:768px){#content{margin-bottom:1.25em}
+.sect1{padding-bottom:1.25em}}
+.sect1:last-child{padding-bottom:0}
+.sect1+.sect1{border-top:1px solid #e7e7e9}
+#content h1>a.anchor,h2>a.anchor,h3>a.anchor,#toctitle>a.anchor,.sidebarblock>.content>.title>a.anchor,h4>a.anchor,h5>a.anchor,h6>a.anchor{position:absolute;z-index:1001;width:1.5ex;margin-left:-1.5ex;display:block;text-decoration:none!important;visibility:hidden;text-align:center;font-weight:400}
+#content h1>a.anchor::before,h2>a.anchor::before,h3>a.anchor::before,#toctitle>a.anchor::before,.sidebarblock>.content>.title>a.anchor::before,h4>a.anchor::before,h5>a.anchor::before,h6>a.anchor::before{content:"\00A7";font-size:.85em;display:block;padding-top:.1em}
+#content h1:hover>a.anchor,#content h1>a.anchor:hover,h2:hover>a.anchor,h2>a.anchor:hover,h3:hover>a.anchor,#toctitle:hover>a.anchor,.sidebarblock>.content>.title:hover>a.anchor,h3>a.anchor:hover,#toctitle>a.anchor:hover,.sidebarblock>.content>.title>a.anchor:hover,h4:hover>a.anchor,h4>a.anchor:hover,h5:hover>a.anchor,h5>a.anchor:hover,h6:hover>a.anchor,h6>a.anchor:hover{visibility:visible}
+#content h1>a.link,h2>a.link,h3>a.link,#toctitle>a.link,.sidebarblock>.content>.title>a.link,h4>a.link,h5>a.link,h6>a.link{color:#ba3925;text-decoration:none}
+#content h1>a.link:hover,h2>a.link:hover,h3>a.link:hover,#toctitle>a.link:hover,.sidebarblock>.content>.title>a.link:hover,h4>a.link:hover,h5>a.link:hover,h6>a.link:hover{color:#a53221}
+.audioblock,.imageblock,.literalblock,.listingblock,.stemblock,.videoblock{margin-bottom:1.25em}
+.admonitionblock td.content>.title,.audioblock>.title,.exampleblock>.title,.imageblock>.title,.listingblock>.title,.literalblock>.title,.stemblock>.title,.openblock>.title,.paragraph>.title,.quoteblock>.title,table.tableblock>.title,.verseblock>.title,.videoblock>.title,.dlist>.title,.olist>.title,.ulist>.title,.qlist>.title,.hdlist>.title{text-rendering:optimizeLegibility;text-align:left;font-family:"Noto Serif","DejaVu Serif",serif;font-size:1rem;font-style:italic}
+table.tableblock.fit-content>caption.title{white-space:nowrap;width:0}
+.paragraph.lead>p,#preamble>.sectionbody>[class="paragraph"]:first-of-type p{font-size:1.21875em;line-height:1.6;color:rgba(0,0,0,.85)}
+table.tableblock #preamble>.sectionbody>[class="paragraph"]:first-of-type p{font-size:inherit}
+.admonitionblock>table{border-collapse:separate;border:0;background:none;width:100%}
+.admonitionblock>table td.icon{text-align:center;width:80px}
+.admonitionblock>table td.icon img{max-width:none}
+.admonitionblock>table td.icon .title{font-weight:bold;font-family:"Open Sans","DejaVu Sans",sans-serif;text-transform:uppercase}
+.admonitionblock>table td.content{padding-left:1.125em;padding-right:1.25em;border-left:1px solid #dddddf;color:rgba(0,0,0,.6)}
+.admonitionblock>table td.content>:last-child>:last-child{margin-bottom:0}
+.exampleblock>.content{border-style:solid;border-width:1px;border-color:#e6e6e6;margin-bottom:1.25em;padding:1.25em;background:#fff;-webkit-border-radius:4px;border-radius:4px}
+.exampleblock>.content>:first-child{margin-top:0}
+.exampleblock>.content>:last-child{margin-bottom:0}
+.sidebarblock{border-style:solid;border-width:1px;border-color:#e0e0dc;margin-bottom:1.25em;padding:1.25em;background:#f8f8f7;-webkit-border-radius:4px;border-radius:4px}
+.sidebarblock>:first-child{margin-top:0}
+.sidebarblock>:last-child{margin-bottom:0}
+.sidebarblock>.content>.title{color:#7a2518;margin-top:0;text-align:center}
+.exampleblock>.content>:last-child>:last-child,.exampleblock>.content .olist>ol>li:last-child>:last-child,.exampleblock>.content .ulist>ul>li:last-child>:last-child,.exampleblock>.content .qlist>ol>li:last-child>:last-child,.sidebarblock>.content>:last-child>:last-child,.sidebarblock>.content .olist>ol>li:last-child>:last-child,.sidebarblock>.content .ulist>ul>li:last-child>:last-child,.sidebarblock>.content .qlist>ol>li:last-child>:last-child{margin-bottom:0}
+.literalblock pre,.listingblock pre:not(.highlight),.listingblock pre[class="highlight"],.listingblock pre[class^="highlight "],.listingblock pre.CodeRay,.listingblock pre.prettyprint{background:#f7f7f8}
+.sidebarblock .literalblock pre,.sidebarblock .listingblock pre:not(.highlight),.sidebarblock .listingblock pre[class="highlight"],.sidebarblock .listingblock pre[class^="highlight "],.sidebarblock .listingblock pre.CodeRay,.sidebarblock .listingblock pre.prettyprint{background:#f2f1f1}
+.literalblock pre,.literalblock pre[class],.listingblock pre,.listingblock pre[class]{-webkit-border-radius:4px;border-radius:4px;word-wrap:break-word;overflow-x:auto;padding:1em;font-size:.8125em}
+@media screen and (min-width:768px){.literalblock pre,.literalblock pre[class],.listingblock pre,.listingblock pre[class]{font-size:.90625em}}
+@media screen and (min-width:1280px){.literalblock pre,.literalblock pre[class],.listingblock pre,.listingblock pre[class]{font-size:1em}}
+.literalblock pre.nowrap,.literalblock pre.nowrap pre,.listingblock pre.nowrap,.listingblock pre.nowrap pre{white-space:pre;word-wrap:normal}
+.literalblock.output pre{color:#f7f7f8;background-color:rgba(0,0,0,.9)}
+.listingblock pre.highlightjs{padding:0}
+.listingblock pre.highlightjs>code{padding:1em;-webkit-border-radius:4px;border-radius:4px}
+.listingblock pre.prettyprint{border-width:0}
+.listingblock>.content{position:relative}
+.listingblock code[data-lang]::before{display:none;content:attr(data-lang);position:absolute;font-size:.75em;top:.425rem;right:.5rem;line-height:1;text-transform:uppercase;color:#999}
+.listingblock:hover code[data-lang]::before{display:block}
+.listingblock.terminal pre .command::before{content:attr(data-prompt);padding-right:.5em;color:#999}
+.listingblock.terminal pre .command:not([data-prompt])::before{content:"$"}
+table.pyhltable{border-collapse:separate;border:0;margin-bottom:0;background:none}
+table.pyhltable td{vertical-align:top;padding-top:0;padding-bottom:0;line-height:1.45}
+table.pyhltable td.code{padding-left:.75em;padding-right:0}
+pre.pygments .lineno,table.pyhltable td:not(.code){color:#999;padding-left:0;padding-right:.5em;border-right:1px solid #dddddf}
+pre.pygments .lineno{display:inline-block;margin-right:.25em}
+table.pyhltable .linenodiv{background:none!important;padding-right:0!important}
+.quoteblock{margin:0 1em 1.25em 1.5em;display:table}
+.quoteblock>.title{margin-left:-1.5em;margin-bottom:.75em}
+.quoteblock blockquote,.quoteblock p{color:rgba(0,0,0,.85);font-size:1.15rem;line-height:1.75;word-spacing:.1em;letter-spacing:0;font-style:italic;text-align:justify}
+.quoteblock blockquote{margin:0;padding:0;border:0}
+.quoteblock blockquote::before{content:"\201c";float:left;font-size:2.75em;font-weight:bold;line-height:.6em;margin-left:-.6em;color:#7a2518;text-shadow:0 1px 2px rgba(0,0,0,.1)}
+.quoteblock blockquote>.paragraph:last-child p{margin-bottom:0}
+.quoteblock .attribution{margin-top:.75em;margin-right:.5ex;text-align:right}
+.verseblock{margin:0 1em 1.25em}
+.verseblock pre{font-family:"Open Sans","DejaVu Sans",sans;font-size:1.15rem;color:rgba(0,0,0,.85);font-weight:300;text-rendering:optimizeLegibility}
+.verseblock pre strong{font-weight:400}
+.verseblock .attribution{margin-top:1.25rem;margin-left:.5ex}
+.quoteblock .attribution,.verseblock .attribution{font-size:.9375em;line-height:1.45;font-style:italic}
+.quoteblock .attribution br,.verseblock .attribution br{display:none}
+.quoteblock .attribution cite,.verseblock .attribution cite{display:block;letter-spacing:-.025em;color:rgba(0,0,0,.6)}
+.quoteblock.abstract blockquote::before,.quoteblock.excerpt blockquote::before,.quoteblock .quoteblock blockquote::before{display:none}
+.quoteblock.abstract blockquote,.quoteblock.abstract p,.quoteblock.excerpt blockquote,.quoteblock.excerpt p,.quoteblock .quoteblock blockquote,.quoteblock .quoteblock p{line-height:1.6;word-spacing:0}
+.quoteblock.abstract{margin:0 1em 1.25em;display:block}
+.quoteblock.abstract>.title{margin:0 0 .375em;font-size:1.15em;text-align:center}
+.quoteblock.excerpt,.quoteblock .quoteblock{margin:0 0 1.25em;padding:0 0 .25em 1em;border-left:.25em solid #dddddf}
+.quoteblock.excerpt blockquote,.quoteblock.excerpt p,.quoteblock .quoteblock blockquote,.quoteblock .quoteblock p{color:inherit;font-size:1.0625rem}
+.quoteblock.excerpt .attribution,.quoteblock .quoteblock .attribution{color:inherit;text-align:left;margin-right:0}
+table.tableblock{max-width:100%;border-collapse:separate}
+p.tableblock:last-child{margin-bottom:0}
+td.tableblock>.content{margin-bottom:-1.25em}
+table.tableblock,th.tableblock,td.tableblock{border:0 solid #dedede}
+table.grid-all>thead>tr>.tableblock,table.grid-all>tbody>tr>.tableblock{border-width:0 1px 1px 0}
+table.grid-all>tfoot>tr>.tableblock{border-width:1px 1px 0 0}
+table.grid-cols>*>tr>.tableblock{border-width:0 1px 0 0}
+table.grid-rows>thead>tr>.tableblock,table.grid-rows>tbody>tr>.tableblock{border-width:0 0 1px}
+table.grid-rows>tfoot>tr>.tableblock{border-width:1px 0 0}
+table.grid-all>*>tr>.tableblock:last-child,table.grid-cols>*>tr>.tableblock:last-child{border-right-width:0}
+table.grid-all>tbody>tr:last-child>.tableblock,table.grid-all>thead:last-child>tr>.tableblock,table.grid-rows>tbody>tr:last-child>.tableblock,table.grid-rows>thead:last-child>tr>.tableblock{border-bottom-width:0}
+table.frame-all{border-width:1px}
+table.frame-sides{border-width:0 1px}
+table.frame-topbot,table.frame-ends{border-width:1px 0}
+table.stripes-all tr,table.stripes-odd tr:nth-of-type(odd){background:#f8f8f7}
+table.stripes-none tr,table.stripes-odd tr:nth-of-type(even){background:none}
+th.halign-left,td.halign-left{text-align:left}
+th.halign-right,td.halign-right{text-align:right}
+th.halign-center,td.halign-center{text-align:center}
+th.valign-top,td.valign-top{vertical-align:top}
+th.valign-bottom,td.valign-bottom{vertical-align:bottom}
+th.valign-middle,td.valign-middle{vertical-align:middle}
+table thead th,table tfoot th{font-weight:bold}
+tbody tr th{display:table-cell;line-height:1.6;background:#f7f8f7}
+tbody tr th,tbody tr th p,tfoot tr th,tfoot tr th p{color:rgba(0,0,0,.8);font-weight:bold}
+p.tableblock>code:only-child{background:none;padding:0}
+p.tableblock{font-size:1em}
+td>div.verse{white-space:pre}
+ol{margin-left:1.75em}
+ul li ol{margin-left:1.5em}
+dl dd{margin-left:1.125em}
+dl dd:last-child,dl dd:last-child>:last-child{margin-bottom:0}
+ol>li p,ul>li p,ul dd,ol dd,.olist .olist,.ulist .ulist,.ulist .olist,.olist .ulist{margin-bottom:.625em}
+ul.checklist,ul.none,ol.none,ul.no-bullet,ol.no-bullet,ol.unnumbered,ul.unstyled,ol.unstyled{list-style-type:none}
+ul.no-bullet,ol.no-bullet,ol.unnumbered{margin-left:.625em}
+ul.unstyled,ol.unstyled{margin-left:0}
+ul.checklist{margin-left:.625em}
+ul.checklist li>p:first-child>.fa-square-o:first-child,ul.checklist li>p:first-child>.fa-check-square-o:first-child{width:1.25em;font-size:.8em;position:relative;bottom:.125em}
+ul.checklist li>p:first-child>input[type="checkbox"]:first-child{margin-right:.25em}
+ul.inline{display:-ms-flexbox;display:-webkit-box;display:flex;-ms-flex-flow:row wrap;-webkit-flex-flow:row wrap;flex-flow:row wrap;list-style:none;margin:0 0 .625em -1.25em}
+ul.inline>li{margin-left:1.25em}
+.unstyled dl dt{font-weight:400;font-style:normal}
+ol.arabic{list-style-type:decimal}
+ol.decimal{list-style-type:decimal-leading-zero}
+ol.loweralpha{list-style-type:lower-alpha}
+ol.upperalpha{list-style-type:upper-alpha}
+ol.lowerroman{list-style-type:lower-roman}
+ol.upperroman{list-style-type:upper-roman}
+ol.lowergreek{list-style-type:lower-greek}
+.hdlist>table,.colist>table{border:0;background:none}
+.hdlist>table>tbody>tr,.colist>table>tbody>tr{background:none}
+td.hdlist1,td.hdlist2{vertical-align:top;padding:0 .625em}
+td.hdlist1{font-weight:bold;padding-bottom:1.25em}
+.literalblock+.colist,.listingblock+.colist{margin-top:-.5em}
+.colist td:not([class]):first-child{padding:.4em .75em 0;line-height:1;vertical-align:top}
+.colist td:not([class]):first-child img{max-width:none}
+.colist td:not([class]):last-child{padding:.25em 0}
+.thumb,.th{line-height:0;display:inline-block;border:solid 4px #fff;-webkit-box-shadow:0 0 0 1px #ddd;box-shadow:0 0 0 1px #ddd}
+.imageblock.left{margin:.25em .625em 1.25em 0}
+.imageblock.right{margin:.25em 0 1.25em .625em}
+.imageblock>.title{margin-bottom:0}
+.imageblock.thumb,.imageblock.th{border-width:6px}
+.imageblock.thumb>.title,.imageblock.th>.title{padding:0 .125em}
+.image.left,.image.right{margin-top:.25em;margin-bottom:.25em;display:inline-block;line-height:0}
+.image.left{margin-right:.625em}
+.image.right{margin-left:.625em}
+a.image{text-decoration:none;display:inline-block}
+a.image object{pointer-events:none}
+sup.footnote,sup.footnoteref{font-size:.875em;position:static;vertical-align:super}
+sup.footnote a,sup.footnoteref a{text-decoration:none}
+sup.footnote a:active,sup.footnoteref a:active{text-decoration:underline}
+#footnotes{padding-top:.75em;padding-bottom:.75em;margin-bottom:.625em}
+#footnotes hr{width:20%;min-width:6.25em;margin:-.25em 0 .75em;border-width:1px 0 0}
+#footnotes .footnote{padding:0 .375em 0 .225em;line-height:1.3334;font-size:.875em;margin-left:1.2em;margin-bottom:.2em}
+#footnotes .footnote a:first-of-type{font-weight:bold;text-decoration:none;margin-left:-1.05em}
+#footnotes .footnote:last-of-type{margin-bottom:0}
+#content #footnotes{margin-top:-.625em;margin-bottom:0;padding:.75em 0}
+.gist .file-data>table{border:0;background:#fff;width:100%;margin-bottom:0}
+.gist .file-data>table td.line-data{width:99%}
+div.unbreakable{page-break-inside:avoid}
+.big{font-size:larger}
+.small{font-size:smaller}
+.underline{text-decoration:underline}
+.overline{text-decoration:overline}
+.line-through{text-decoration:line-through}
+.aqua{color:#00bfbf}
+.aqua-background{background-color:#00fafa}
+.black{color:#000}
+.black-background{background-color:#000}
+.blue{color:#0000bf}
+.blue-background{background-color:#0000fa}
+.fuchsia{color:#bf00bf}
+.fuchsia-background{background-color:#fa00fa}
+.gray{color:#606060}
+.gray-background{background-color:#7d7d7d}
+.green{color:#006000}
+.green-background{background-color:#007d00}
+.lime{color:#00bf00}
+.lime-background{background-color:#00fa00}
+.maroon{color:#600000}
+.maroon-background{background-color:#7d0000}
+.navy{color:#000060}
+.navy-background{background-color:#00007d}
+.olive{color:#606000}
+.olive-background{background-color:#7d7d00}
+.purple{color:#600060}
+.purple-background{background-color:#7d007d}
+.red{color:#bf0000}
+.red-background{background-color:#fa0000}
+.silver{color:#909090}
+.silver-background{background-color:#bcbcbc}
+.teal{color:#006060}
+.teal-background{background-color:#007d7d}
+.white{color:#bfbfbf}
+.white-background{background-color:#fafafa}
+.yellow{color:#bfbf00}
+.yellow-background{background-color:#fafa00}
+span.icon>.fa{cursor:default}
+a span.icon>.fa{cursor:inherit}
+.admonitionblock td.icon [class^="fa icon-"]{font-size:2.5em;text-shadow:1px 1px 2px rgba(0,0,0,.5);cursor:default}
+.admonitionblock td.icon .icon-note::before{content:"\f05a";color:#19407c}
+.admonitionblock td.icon .icon-tip::before{content:"\f0eb";text-shadow:1px 1px 2px rgba(155,155,0,.8);color:#111}
+.admonitionblock td.icon .icon-warning::before{content:"\f071";color:#bf6900}
+.admonitionblock td.icon .icon-caution::before{content:"\f06d";color:#bf3400}
+.admonitionblock td.icon .icon-important::before{content:"\f06a";color:#bf0000}
+.conum[data-value]{display:inline-block;color:#fff!important;background-color:rgba(0,0,0,.8);-webkit-border-radius:100px;border-radius:100px;text-align:center;font-size:.75em;width:1.67em;height:1.67em;line-height:1.67em;font-family:"Open Sans","DejaVu Sans",sans-serif;font-style:normal;font-weight:bold}
+.conum[data-value] *{color:#fff!important}
+.conum[data-value]+b{display:none}
+.conum[data-value]::after{content:attr(data-value)}
+pre .conum[data-value]{position:relative;top:-.125em}
+b.conum *{color:inherit!important}
+.conum:not([data-value]):empty{display:none}
+dt,th.tableblock,td.content,div.footnote{text-rendering:optimizeLegibility}
+h1,h2,p,td.content,span.alt{letter-spacing:-.01em}
+p strong,td.content strong,div.footnote strong{letter-spacing:-.005em}
+p,blockquote,dt,td.content,span.alt{font-size:1.0625rem}
+p{margin-bottom:1.25rem}
+.sidebarblock p,.sidebarblock dt,.sidebarblock td.content,p.tableblock{font-size:1em}
+.exampleblock>.content{background-color:#fffef7;border-color:#e0e0dc;-webkit-box-shadow:0 1px 4px #e0e0dc;box-shadow:0 1px 4px #e0e0dc}
+.print-only{display:none!important}
+@page{margin:1.25cm .75cm}
+@media print{*{-webkit-box-shadow:none!important;box-shadow:none!important;text-shadow:none!important}
+html{font-size:80%}
+a{color:inherit!important;text-decoration:underline!important}
+a.bare,a[href^="#"],a[href^="mailto:"]{text-decoration:none!important}
+a[href^="http:"]:not(.bare)::after,a[href^="https:"]:not(.bare)::after{content:"(" attr(href) ")";display:inline-block;font-size:.875em;padding-left:.25em}
+abbr[title]::after{content:" (" attr(title) ")"}
+pre,blockquote,tr,img,object,svg{page-break-inside:avoid}
+thead{display:table-header-group}
+svg{max-width:100%}
+p,blockquote,dt,td.content{font-size:1em;orphans:3;widows:3}
+h2,h3,#toctitle,.sidebarblock>.content>.title{page-break-after:avoid}
+#toc,.sidebarblock,.exampleblock>.content{background:none!important}
+#toc{border-bottom:1px solid #dddddf!important;padding-bottom:0!important}
+body.book #header{text-align:center}
+body.book #header>h1:first-child{border:0!important;margin:2.5em 0 1em}
+body.book #header .details{border:0!important;display:block;padding:0!important}
+body.book #header .details span:first-child{margin-left:0!important}
+body.book #header .details br{display:block}
+body.book #header .details br+span::before{content:none!important}
+body.book #toc{border:0!important;text-align:left!important;padding:0!important;margin:0!important}
+body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-break-before:always}
+.listingblock code[data-lang]::before{display:block}
+#footer{padding:0 .9375em}
+.hide-on-print{display:none!important}
+.print-only{display:block!important}
+.hide-for-print{display:none!important}
+.show-for-print{display:inherit!important}}
+@media print,amzn-kf8{#header>h1:first-child{margin-top:1.25rem}
+.sect1{padding:0!important}
+.sect1+.sect1{border:0}
+#footer{background:none}
+#footer-text{color:rgba(0,0,0,.6);font-size:.9em}}
+@media amzn-kf8{#header,#content,#footnotes,#footer{padding:0}}
+</style>
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css">
+</head>
+<body class="book toc2 toc-left">
+<div id="header">
+<h1>Product API Docs</h1>
+<div class="details">
+<span id="author" class="author">Junghyungile&lt;junghyungile@gmail.com&gt;</span><br>
+</div>
+<div id="toc" class="toc2">
+<div id="toctitle">Table of Contents</div>
+<ul class="sectlevel1">
+<li><a href="#overview_http_verbs">HTTP Methods</a></li>
+<li><a href="#overview_http_status_codes">HTTP status codes</a></li>
+<li><a href="#_product_api">Product API</a></li>
+<li><a href="#_상품_등록">● 상품 등록</a>
+<ul class="sectlevel2">
+<li><a href="#_1_1_상품_등록에_성공할_경우_http_status_code_201created를_리턴">1-1 상품 등록에 성공할 경우 Http Status Code 201(Created)를 리턴</a></li>
+<li><a href="#_1_2_상품_이름에_null을_등록하여_실패한_경우_http_status_code_400badrequest를_리턴">1-2 상품 이름에 Null을 등록하여 실패한 경우 Http Status Code 400(BadRequest)를 리턴</a></li>
+<li><a href="#_1_3_상품_이름에_null이나_빈_값_또는_공_백을_등록하여_실패한_경우_http_status_code_400badrequest를_리턴">1-3 상품 이름에 null이나 빈 값 또는 공 백을 등록하여 실패한 경우 Http Status Code 400(BadRequest)를 리턴</a></li>
+<li><a href="#_1_4_상품_이름에_null이나_공백을_등록하여_실패한_경우_http_status_code_400badrequest를_리턴">1-4 상품 이름에 null이나 공백을 등록하여 실패한 경우 Http Status Code 400(BadRequest)를 리턴</a></li>
+</ul>
+</li>
+<li><a href="#_상품_조회">● 상품 조회</a>
+<ul class="sectlevel2">
+<li><a href="#_1_1_특정_상품_조회에_성공할_경우_http_status_code_201created를_리턴">1-1 특정 상품 조회에 성공할 경우 Http Status Code 201(Created)를 리턴</a></li>
+<li><a href="#_1_2_전체_상품_조회에_성공할_경우_http_status_code_201created를_리턴">1-2 전체 상품 조회에 성공할 경우 Http Status Code 201(Created)를 리턴</a></li>
+</ul>
+</li>
+<li><a href="#_상품_수정">● 상품 수정</a>
+<ul class="sectlevel2">
+<li><a href="#_1_1_상품_수정에_성공할_경우_http_status_code_201created를_리턴">1-1 상품 수정에 성공할 경우 Http Status Code 201(Created)를 리턴</a></li>
+</ul>
+</li>
+<li><a href="#_상품_삭제">● 상품 삭제</a>
+<ul class="sectlevel2">
+<li><a href="#_1_1_상품_삭제에_성공할_경우_http_status_code_201created를_리턴">1-1 상품 삭제에 성공할 경우 Http Status Code 201(Created)를 리턴</a></li>
+</ul>
+</li>
+</ul>
+</div>
+</div>
+<div id="content">
+<div class="sect1">
+<h2 id="overview_http_verbs"><a class="link" href="#overview_http_verbs">HTTP Methods</a></h2>
+<div class="sectionbody">
+<div class="paragraph">
+<p>클라이언트와 서버 사이에 이루어지는 요청(Request)과 응답(Response) 데이터를 전송하는 방식입니다.</p>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 50%;">
+<col style="width: 50%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Method</th>
+<th class="tableblock halign-left valign-top">Content</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>GET</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">요청받은 URI의 정보를 검색하여 응답합니다.</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>POST</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">요청된 자원을 생성(CREATE) 합니다.</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>PUT</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">요청된 자원을 수정(UPDATE)한다. 리소스의 모든 것을 업데이트 합니다..</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>PATCH</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">PUT과 유사하게 요청된 자원을 수정(UPATE) 할 때 사용한다. 리소스의 일부를 업데이트 합니다.</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>DELETE</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">요청된 자원을 삭제할 것을 요청합니다.</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+</div>
+<div class="sect1">
+<h2 id="overview_http_status_codes"><a class="link" href="#overview_http_status_codes">HTTP status codes</a></h2>
+<div class="sectionbody">
+<div class="paragraph">
+<p>모든 HTTP 응답 코드는 5개의 클래스(분류)로 구분된다. 상태 코드의 첫 번째 숫자는 응답의 클래스를 정의한다. 첫자리에 대한 5가지 값들은 다음과 같습니다:</p>
+</div>
+<div class="paragraph">
+<p>1xx (정보): 요청을 받았으며 프로세스를 계속합니다.</p>
+</div>
+<div class="paragraph">
+<p>2xx (성공): 요청을 성공적으로 받았으며 인식했고 수용합니다.</p>
+</div>
+<div class="paragraph">
+<p>3xx (리다이렉션): 요청 완료를 위해 추가 작업 조치가 필요합니다.</p>
+</div>
+<div class="paragraph">
+<p>4xx (클라이언트 오류): 요청의 문법이 잘못되었거나 요청을 처리할 수 없습니다.</p>
+</div>
+<div class="paragraph">
+<p>5xx (서버 오류): 서버가 명백히 유효한 요청에 대해 충족을 실패습니다.</p>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 50%;">
+<col style="width: 50%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Status code</th>
+<th class="tableblock halign-left valign-top">Usage</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>200 OK</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">요청이 성공적으로 되었습니다.</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>201 Created</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">요청이 성공적이었으며 그 결과로 새로운 리소스가 생성되었습니다. 이 응답은 일반적으로 POST 요청 또는 일부 PUT 요청 이후에 따라옵니다.</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>400 Bad Request</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">이 응답은 잘못된 문법으로 인하여 서버가 요청을 이해할 수 없음을 의미합니다.</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>404 NotFoundException</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">클라이언트의 요청에 관해 서버가 요청받은 리소스를 찾을 수 없다는 것을 의미합니다.</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>409 Conflict</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">서버가 요청을 수행하는 중에 충돌이 발생했습니다. 서버는 응답할 때 충돌에 대한 정보를 포함해야 합니다.</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+</div>
+<div class="sect1">
+<h2 id="_product_api"><a class="link" href="#_product_api">Product API</a></h2>
+<div class="sectionbody">
+
+</div>
+</div>
+<div class="sect1">
+<h2 id="_상품_등록"><a class="link" href="#_상품_등록">● 상품 등록</a></h2>
+<div class="sectionbody">
+<div class="sect2">
+<h3 id="_1_1_상품_등록에_성공할_경우_http_status_code_201created를_리턴"><a class="link" href="#_1_1_상품_등록에_성공할_경우_http_status_code_201created를_리턴">1-1 상품 등록에 성공할 경우 Http Status Code 201(Created)를 리턴</a></h3>
+<div class="paragraph">
+<p><strong>curl</strong></p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight"><code class="language-bash hljs" data-lang="bash">$ curl 'http://localhost:8081/products' -i -X POST \
+    -H 'Content-Type: application/json;charset=UTF-8' \
+    -d '{
+  "productName" : "상품"
+}'</code></pre>
+</div>
+</div>
+<div class="paragraph">
+<p><strong>요청 필드</strong></p>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 33.3333%;">
+<col style="width: 33.3333%;">
+<col style="width: 33.3334%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Path</th>
+<th class="tableblock halign-left valign-top">Type</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>productName</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">상품명</p></td>
+</tr>
+</tbody>
+</table>
+<div class="paragraph">
+<p><strong>요청 예시</strong></p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /products HTTP/1.1
+Content-Type: application/json;charset=UTF-8
+Content-Length: 32
+Host: localhost:8081
+
+{
+  "productName" : "상품"
+}</code></pre>
+</div>
+</div>
+<div class="paragraph">
+<p><strong>응답 예시</strong></p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 201 Created</code></pre>
+</div>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_1_2_상품_이름에_null을_등록하여_실패한_경우_http_status_code_400badrequest를_리턴"><a class="link" href="#_1_2_상품_이름에_null을_등록하여_실패한_경우_http_status_code_400badrequest를_리턴">1-2 상품 이름에 Null을 등록하여 실패한 경우 Http Status Code 400(BadRequest)를 리턴</a></h3>
+<div class="paragraph">
+<p><strong>curl</strong></p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight"><code class="language-bash hljs" data-lang="bash">$ curl 'http://localhost:8081/products' -i -X POST \
+    -H 'Content-Type: application/json;charset=UTF-8' \
+    -d '{
+  "productName" : null
+}'</code></pre>
+</div>
+</div>
+<div class="paragraph">
+<p><strong>요청 필드</strong></p>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 33.3333%;">
+<col style="width: 33.3333%;">
+<col style="width: 33.3334%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Path</th>
+<th class="tableblock halign-left valign-top">Type</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>productName</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Null</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">요청한 상품명이 null 일 때</p></td>
+</tr>
+</tbody>
+</table>
+<div class="paragraph">
+<p><strong>요청 예시</strong></p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /products HTTP/1.1
+Content-Type: application/json;charset=UTF-8
+Content-Length: 28
+Host: localhost:8081
+
+{
+  "productName" : null
+}</code></pre>
+</div>
+</div>
+<div class="paragraph">
+<p><strong>응답 예시</strong></p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 400 Bad Request
+Content-Type: application/json;charset=UTF-8
+Content-Length: 55
+
+{
+  "message" : "잘못된 상품 이름입니다."
+}</code></pre>
+</div>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_1_3_상품_이름에_null이나_빈_값_또는_공_백을_등록하여_실패한_경우_http_status_code_400badrequest를_리턴"><a class="link" href="#_1_3_상품_이름에_null이나_빈_값_또는_공_백을_등록하여_실패한_경우_http_status_code_400badrequest를_리턴">1-3 상품 이름에 null이나 빈 값 또는 공 백을 등록하여 실패한 경우 Http Status Code 400(BadRequest)를 리턴</a></h3>
+<div class="paragraph">
+<p><strong>curl</strong></p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight"><code class="language-bash hljs" data-lang="bash">$ curl 'http://localhost:8081/products' -i -X POST \
+    -H 'Content-Type: application/json;charset=UTF-8' \
+    -d '{
+  "productName" : ""
+}'</code></pre>
+</div>
+</div>
+<div class="paragraph">
+<p><strong>요청 필드</strong></p>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 33.3333%;">
+<col style="width: 33.3333%;">
+<col style="width: 33.3334%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Path</th>
+<th class="tableblock halign-left valign-top">Type</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>productName</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">요청한 상품명이 빈값일 떼</p></td>
+</tr>
+</tbody>
+</table>
+<div class="paragraph">
+<p><strong>요청 예시</strong></p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /products HTTP/1.1
+Content-Type: application/json;charset=UTF-8
+Content-Length: 26
+Host: localhost:8081
+
+{
+  "productName" : ""
+}</code></pre>
+</div>
+</div>
+<div class="paragraph">
+<p><strong>응답 예시</strong></p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 400 Bad Request
+Content-Type: application/json;charset=UTF-8
+Content-Length: 55
+
+{
+  "message" : "잘못된 상품 이름입니다."
+}</code></pre>
+</div>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_1_4_상품_이름에_null이나_공백을_등록하여_실패한_경우_http_status_code_400badrequest를_리턴"><a class="link" href="#_1_4_상품_이름에_null이나_공백을_등록하여_실패한_경우_http_status_code_400badrequest를_리턴">1-4 상품 이름에 null이나 공백을 등록하여 실패한 경우 Http Status Code 400(BadRequest)를 리턴</a></h3>
+<div class="paragraph">
+<p><strong>curl</strong></p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight"><code class="language-bash hljs" data-lang="bash">$ curl 'http://localhost:8081/products' -i -X POST \
+    -H 'Content-Type: application/json;charset=UTF-8' \
+    -d '{
+  "productName" : " "
+}'</code></pre>
+</div>
+</div>
+<div class="paragraph">
+<p><strong>요청 필드</strong></p>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 33.3333%;">
+<col style="width: 33.3333%;">
+<col style="width: 33.3334%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Path</th>
+<th class="tableblock halign-left valign-top">Type</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>productName</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">요청한 상품명이 공백일때</p></td>
+</tr>
+</tbody>
+</table>
+<div class="paragraph">
+<p><strong>요청 예시</strong></p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /products HTTP/1.1
+Content-Type: application/json;charset=UTF-8
+Content-Length: 27
+Host: localhost:8081
+
+{
+  "productName" : " "
+}</code></pre>
+</div>
+</div>
+<div class="paragraph">
+<p><strong>응답 예시</strong></p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 400 Bad Request
+Content-Type: application/json;charset=UTF-8
+Content-Length: 55
+
+{
+  "message" : "잘못된 상품 이름입니다."
+}</code></pre>
+</div>
+</div>
+</div>
+</div>
+</div>
+<div class="sect1">
+<h2 id="_상품_조회"><a class="link" href="#_상품_조회">● 상품 조회</a></h2>
+<div class="sectionbody">
+<div class="sect2">
+<h3 id="_1_1_특정_상품_조회에_성공할_경우_http_status_code_201created를_리턴"><a class="link" href="#_1_1_특정_상품_조회에_성공할_경우_http_status_code_201created를_리턴">1-1 특정 상품 조회에 성공할 경우 Http Status Code 201(Created)를 리턴</a></h3>
+<div class="paragraph">
+<p><strong>curl</strong></p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight"><code class="language-bash hljs" data-lang="bash">$ curl 'http://localhost:8081/products/1' -i -X GET \
+    -H 'Content-Type: application/json;charset=UTF-8'</code></pre>
+</div>
+</div>
+<div class="paragraph">
+<p><strong>요청 예시</strong></p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /products/1 HTTP/1.1
+Content-Type: application/json;charset=UTF-8
+Host: localhost:8081</code></pre>
+</div>
+</div>
+<div class="paragraph">
+<p><strong>응답 필드</strong></p>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 33.3333%;">
+<col style="width: 33.3333%;">
+<col style="width: 33.3334%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Path</th>
+<th class="tableblock halign-left valign-top">Type</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>productName</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">조회한 상품명</p></td>
+</tr>
+</tbody>
+</table>
+<div class="paragraph">
+<p><strong>응답 예시</strong></p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 200 OK
+Content-Type: application/json;charset=UTF-8
+Content-Length: 32
+
+{
+  "productName" : "상품"
+}</code></pre>
+</div>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_1_2_전체_상품_조회에_성공할_경우_http_status_code_201created를_리턴"><a class="link" href="#_1_2_전체_상품_조회에_성공할_경우_http_status_code_201created를_리턴">1-2 전체 상품 조회에 성공할 경우 Http Status Code 201(Created)를 리턴</a></h3>
+<div class="paragraph">
+<p><strong>curl</strong></p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight"><code class="language-bash hljs" data-lang="bash">$ curl 'http://localhost:8081/products?page=0&amp;size=2' -i -X GET \
+    -H 'Content-Type: application/json;charset=UTF-8'</code></pre>
+</div>
+</div>
+<div class="paragraph">
+<p><strong>요청 예시</strong></p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /products?page=0&amp;size=2 HTTP/1.1
+Content-Type: application/json;charset=UTF-8
+Host: localhost:8081</code></pre>
+</div>
+</div>
+<div class="paragraph">
+<p><strong>응답 필드</strong></p>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 33.3333%;">
+<col style="width: 33.3333%;">
+<col style="width: 33.3334%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Path</th>
+<th class="tableblock halign-left valign-top">Type</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>[].productId</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">상품 번호</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>[].productName</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">조회한 상품명</p></td>
+</tr>
+</tbody>
+</table>
+<div class="paragraph">
+<p><strong>응답 예시</strong></p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 200 OK
+Content-Type: application/json;charset=UTF-8
+Content-Length: 111
+
+[ {
+  "productId" : 1,
+  "productName" : "상품"
+}, {
+  "productId" : 2,
+  "productName" : "상품2"
+} ]</code></pre>
+</div>
+</div>
+</div>
+</div>
+</div>
+<div class="sect1">
+<h2 id="_상품_수정"><a class="link" href="#_상품_수정">● 상품 수정</a></h2>
+<div class="sectionbody">
+<div class="sect2">
+<h3 id="_1_1_상품_수정에_성공할_경우_http_status_code_201created를_리턴"><a class="link" href="#_1_1_상품_수정에_성공할_경우_http_status_code_201created를_리턴">1-1 상품 수정에 성공할 경우 Http Status Code 201(Created)를 리턴</a></h3>
+<div class="paragraph">
+<p><strong>curl</strong></p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight"><code class="language-bash hljs" data-lang="bash">$ curl 'http://localhost:8081/products/1' -i -X PUT \
+    -H 'Content-Type: application/json;charset=UTF-8' \
+    -d '{
+  "productName" : "상품상품"
+}'</code></pre>
+</div>
+</div>
+<div class="paragraph">
+<p><strong>path-parameters</strong>
+./products/{id}</p>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 50%;">
+<col style="width: 50%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Parameter</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>id</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">수정할 상품의 번호</p></td>
+</tr>
+</tbody>
+</table>
+<div class="paragraph">
+<p><strong>요청 예시</strong></p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">PUT /products/1 HTTP/1.1
+Content-Type: application/json;charset=UTF-8
+Content-Length: 38
+Host: localhost:8081
+
+{
+  "productName" : "상품상품"
+}</code></pre>
+</div>
+</div>
+<div class="paragraph">
+<p><strong>응답 예시</strong></p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 201 Created</code></pre>
+</div>
+</div>
+</div>
+</div>
+</div>
+<div class="sect1">
+<h2 id="_상품_삭제"><a class="link" href="#_상품_삭제">● 상품 삭제</a></h2>
+<div class="sectionbody">
+<div class="sect2">
+<h3 id="_1_1_상품_삭제에_성공할_경우_http_status_code_201created를_리턴"><a class="link" href="#_1_1_상품_삭제에_성공할_경우_http_status_code_201created를_리턴">1-1 상품 삭제에 성공할 경우 Http Status Code 201(Created)를 리턴</a></h3>
+<div class="paragraph">
+<p><strong>curl</strong></p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight"><code class="language-bash hljs" data-lang="bash">$ curl 'http://localhost:8080/products/1' -i -X DELETE \
+    -H 'Content-Type: application/json;charset=UTF-8'</code></pre>
+</div>
+</div>
+<div class="paragraph">
+<p><strong>path-parameters</strong>
+./products/{id}</p>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 50%;">
+<col style="width: 50%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Parameter</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>id</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">삭제할 상품의 번호</p></td>
+</tr>
+</tbody>
+</table>
+<div class="paragraph">
+<p><strong>요청 예시</strong></p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">DELETE /products/1 HTTP/1.1
+Content-Type: application/json;charset=UTF-8
+Host: localhost:8080</code></pre>
+</div>
+</div>
+<div class="paragraph">
+<p><strong>응답 예시</strong></p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 200 OK</code></pre>
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+<div id="footer">
+<div id="footer-text">
+Last updated 2021-09-29 23:12:00 +0900
+</div>
+</div>
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.13.1/styles/github.min.css">
+<script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.13.1/highlight.min.js"></script>
+<script>hljs.initHighlighting()</script>
+</body>
+</html>

--- a/src/main/java/com/hyungil/productservice/domain/model/BaseTimeEntity.java
+++ b/src/main/java/com/hyungil/productservice/domain/model/BaseTimeEntity.java
@@ -14,6 +14,7 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 @EntityListeners(AuditingEntityListener.class)
 public class BaseTimeEntity {
 
+
 	@CreatedDate
 	@Column(updatable = false)
 	private LocalDateTime createdTime;

--- a/src/main/java/com/hyungil/productservice/domain/model/BaseTimeEntity.java
+++ b/src/main/java/com/hyungil/productservice/domain/model/BaseTimeEntity.java
@@ -14,7 +14,6 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 @EntityListeners(AuditingEntityListener.class)
 public class BaseTimeEntity {
 
-
 	@CreatedDate
 	@Column(updatable = false)
 	private LocalDateTime createdTime;

--- a/src/test/java/com/hyungil/productservice/domain/product/api/ProductApiTest.java
+++ b/src/test/java/com/hyungil/productservice/domain/product/api/ProductApiTest.java
@@ -5,33 +5,58 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.hyungil.productservice.domain.product.dto.request.AddProductRequestDto;
 import com.hyungil.productservice.domain.product.dto.request.UpdateProductRequestDto;
 import com.hyungil.productservice.domain.product.dto.response.GetProductResponseDto;
-import com.hyungil.productservice.domain.product.repository.ProductRepository;
+import com.hyungil.productservice.domain.product.dto.response.GetProductsResponseDto;
 import com.hyungil.productservice.domain.product.service.ProductService;
+import java.util.ArrayList;
+import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
+import org.springframework.restdocs.RestDocumentationContextProvider;
+import org.springframework.restdocs.RestDocumentationExtension;
+import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders;
+import org.springframework.restdocs.operation.preprocess.OperationRequestPreprocessor;
+import org.springframework.restdocs.operation.preprocess.OperationResponsePreprocessor;
+import org.springframework.restdocs.payload.JsonFieldType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.context.WebApplicationContext;
 import org.springframework.web.filter.CharacterEncodingFilter;
 
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.doNothing;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
+import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.documentationConfiguration;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.modifyUris;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessRequest;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessResponse;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
+import static org.springframework.restdocs.request.RequestDocumentation.requestParameters;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 
 @WebMvcTest(ProductApi.class)
+@ExtendWith(RestDocumentationExtension.class)
 @MockBean(JpaMetamodelMappingContext.class)
 class ProductApiTest {
 
@@ -48,9 +73,6 @@ class ProductApiTest {
 	@MockBean
 	private ProductService productService;
 
-	@MockBean
-	private ProductRepository productRepository;
-
 	AddProductRequestDto addProductRequestDto = AddProductRequestDto.builder()
 		.productName("상품")
 		.build();
@@ -63,13 +85,26 @@ class ProductApiTest {
 		.productName("상품상품")
 		.build();
 
+	GetProductsResponseDto getProductsResponseDto = GetProductsResponseDto.builder()
+		.productId(1L).productName("상품").build();
+
+	GetProductsResponseDto getProductsResponseDto2 = GetProductsResponseDto.builder()
+		.productId(2L).productName("상품2").build();
+
+	List<GetProductsResponseDto> productList = new ArrayList<>();
+
 	@BeforeEach
-	void beforeEach() {
+	void setUp(RestDocumentationContextProvider restDocumentation) {
+
 		mockMvc = MockMvcBuilders
 			.webAppContextSetup(webApplicationContext)
+			.apply(documentationConfiguration(restDocumentation))
 			.addFilters(new CharacterEncodingFilter("UTF-8", true))
 			.alwaysDo(print())
 			.build();
+
+		productList.add(getProductsResponseDto);
+		productList.add(getProductsResponseDto2);
 	}
 
 	@Test
@@ -82,45 +117,26 @@ class ProductApiTest {
 			.contentType(MediaType.APPLICATION_JSON)
 			.content(toJsonString(addProductRequestDto))
 		)
-			.andExpect(status().isCreated());
+			.andExpect(status().isCreated())
+			.andDo(
+				document(
+					"products/create/successful", getDocumentRequest(), getDocumentResponse(),
+
+					requestHeaders(
+						headerWithName(HttpHeaders.CONTENT_TYPE).description("Content-type")
+					),
+
+					requestFields(
+						fieldWithPath("productName").type(JsonFieldType.STRING).description("상품명")
+					)
+				)
+			);
 	}
 
 
 	@Test
 	@DisplayName("상품 이름에 Null을 등록하여 실패한 경우 Http Status Code 400(BadRequest)를 리턴")
 	void addProductIfNameIsNull() throws Exception {
-
-		addProductRequestDto = AddProductRequestDto.builder()
-			.productName("")
-			.build();
-
-		mockMvc.perform(post("/products")
-			.contentType(MediaType.APPLICATION_JSON)
-			.content(toJsonString(addProductRequestDto))
-		)
-			.andExpect(status().isBadRequest())
-			.andExpect(jsonPath("$.message").value("잘못된 상품 이름입니다."));
-	}
-
-	@Test
-	@DisplayName("상품 이름에 null이나 빈 값 또는 공 백을 등록하여 실패한 경우 Http Status Code 400(BadRequest)를 리턴")
-	void addProductIfNameEmptyString() throws Exception {
-
-		addProductRequestDto = AddProductRequestDto.builder()
-			.productName(" ")
-			.build();
-
-		mockMvc.perform(post("/products")
-			.contentType(MediaType.APPLICATION_JSON)
-			.content(toJsonString(addProductRequestDto))
-		)
-			.andExpect(status().isBadRequest())
-			.andExpect(jsonPath("$.message").value("잘못된 상품 이름입니다."));
-	}
-
-	@Test
-	@DisplayName("상품 이름에 null이나 공백을 등록하여 실패한 경우 Http Status Code 400(BadRequest)를 리턴")
-	void addProductIfNameIsBlankString() throws Exception {
 
 		addProductRequestDto = AddProductRequestDto.builder()
 			.productName(null)
@@ -131,7 +147,81 @@ class ProductApiTest {
 			.content(toJsonString(addProductRequestDto))
 		)
 			.andExpect(status().isBadRequest())
-			.andExpect(jsonPath("$.message").value("잘못된 상품 이름입니다."));
+			.andExpect(jsonPath("$.message").value("잘못된 상품 이름입니다."))
+			.andDo(
+				document(
+					"products/null/fail", getDocumentRequest(), getDocumentResponse(),
+
+					requestHeaders(
+						headerWithName(HttpHeaders.CONTENT_TYPE).description("Content-type")
+					),
+
+					requestFields(
+						fieldWithPath("productName").type(JsonFieldType.NULL)
+							.description("요청한 상품명이 null 일 때")
+					)
+				)
+			);
+	}
+
+	@Test
+	@DisplayName("상품 이름에 null이나 빈 값 또는 공 백을 등록하여 실패한 경우 Http Status Code 400(BadRequest)를 리턴")
+	void addProductIfNameEmptyString() throws Exception {
+
+		addProductRequestDto = AddProductRequestDto.builder()
+			.productName("")
+			.build();
+
+		mockMvc.perform(post("/products")
+			.contentType(MediaType.APPLICATION_JSON)
+			.content(toJsonString(addProductRequestDto))
+		)
+			.andExpect(status().isBadRequest())
+			.andExpect(jsonPath("$.message").value("잘못된 상품 이름입니다."))
+			.andDo(
+				document(
+					"products/emptu/fail", getDocumentRequest(), getDocumentResponse(),
+
+					requestHeaders(
+						headerWithName(HttpHeaders.CONTENT_TYPE).description("Content-type")
+					),
+
+					requestFields(
+						fieldWithPath("productName").type(JsonFieldType.STRING)
+							.description("요청한 상품명이 빈값일 떼")
+					)
+				)
+			);
+	}
+
+	@Test
+	@DisplayName("상품 이름에 null이나 공백을 등록하여 실패한 경우 Http Status Code 400(BadRequest)를 리턴")
+	void addProductIfNameIsBlankString() throws Exception {
+
+		addProductRequestDto = AddProductRequestDto.builder()
+			.productName(" ")
+			.build();
+
+		mockMvc.perform(post("/products")
+			.contentType(MediaType.APPLICATION_JSON)
+			.content(toJsonString(addProductRequestDto))
+		)
+			.andExpect(status().isBadRequest())
+			.andExpect(jsonPath("$.message").value("잘못된 상품 이름입니다."))
+			.andDo(
+				document(
+					"products/blank/fail", getDocumentRequest(), getDocumentResponse(),
+
+					requestHeaders(
+						headerWithName(HttpHeaders.CONTENT_TYPE).description("Content-type")
+					),
+
+					requestFields(
+						fieldWithPath("productName").type(JsonFieldType.STRING)
+							.description("요청한 상품명이 공백일때")
+					)
+				)
+			);
 	}
 
 	@Test
@@ -140,22 +230,66 @@ class ProductApiTest {
 
 		given(productService.getProduct(1L)).willReturn(getProductResponseDto);
 
-		mockMvc.perform(get("/products/1")
+		mockMvc.perform(RestDocumentationRequestBuilders.get("/products/{id}", 1)
 			.contentType(MediaType.APPLICATION_JSON)
 		)
 			.andExpect(status().isOk())
-			.andExpect(jsonPath("$.productName").value("상품"));
+			.andExpect(jsonPath("$.productName").value("상품"))
+			.andDo(
+				document(
+					"products/get/successful", getDocumentRequest(), getDocumentResponse(),
+
+					pathParameters(parameterWithName("id").description("조회할 상품의 번호")),
+
+					requestHeaders(
+						headerWithName(HttpHeaders.CONTENT_TYPE).description("Content-type")
+					),
+
+					responseFields(
+						fieldWithPath("productName").type(JsonFieldType.STRING)
+							.description("조회한 상품명")
+					)
+				)
+			);
 	}
 
 	@Test
 	@DisplayName("전체 상품 조회 성공시 Http Status Code 200(Ok) 반환")
 	void getProductsByPagination() throws Exception {
+
+		given(productService.getProductsByPagination(any())).willReturn(productList);
+
 		mockMvc.perform(get("/products")
-			.param("page", "1")
+			.param("page", "0")
 			.param("size", "2")
 			.contentType(MediaType.APPLICATION_JSON))
 
-			.andExpect(status().isOk());
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.[0].productId").value("1"))
+			.andExpect(jsonPath("$.[0].productName").value("상품"))
+			.andExpect(jsonPath("$.[1].productId").value("2"))
+			.andExpect(jsonPath("$.[1].productName").value("상품2"))
+			.andDo(
+				document(
+					"products/all/get/successful", getDocumentRequest(), getDocumentResponse(),
+
+					requestHeaders(
+						headerWithName(HttpHeaders.CONTENT_TYPE).description("Content-type")
+					),
+
+					requestParameters(
+						parameterWithName("page").description("조회할 게시글의 페이지").optional(),
+						parameterWithName("size").description("조회할 게시글의 페이지당 게시글 수").optional()
+					),
+
+					responseFields(
+						fieldWithPath("[].productId").type(JsonFieldType.NUMBER)
+							.description("상품 번호"),
+						fieldWithPath("[].productName").type(JsonFieldType.STRING)
+							.description("조회한 상품명")
+					)
+				)
+			);
 	}
 
 	@Test
@@ -164,11 +298,26 @@ class ProductApiTest {
 
 		doNothing().when(productService).updateProduct(1L, updateProductRequestDto);
 
-		mockMvc.perform(put("/products/1")
+		mockMvc.perform(put("/products/{id}", 1)
 			.contentType(MediaType.APPLICATION_JSON)
 			.content(toJsonString(updateProductRequestDto))
 		)
-			.andExpect(status().isCreated());
+			.andExpect(status().isCreated())
+			.andDo(
+				document(
+					"products/update/successful", getDocumentRequest(), getDocumentResponse(),
+
+					pathParameters(parameterWithName("id").description("수정할 상품의 번호")),
+
+					requestHeaders(
+						headerWithName(HttpHeaders.CONTENT_TYPE).description("Content-type")),
+
+					requestFields(
+						fieldWithPath("productName").type(JsonFieldType.STRING)
+							.description("수정할 상품명")
+					)
+				)
+			);
 	}
 
 	@Test
@@ -177,11 +326,30 @@ class ProductApiTest {
 
 		doNothing().when(productService).deleteProduct(1L);
 
-		mockMvc.perform(delete("/products/{id}", 1)
+		mockMvc.perform(RestDocumentationRequestBuilders.delete("/products/{id}", 1)
 			.contentType(MediaType.APPLICATION_JSON)
 		)
-			.andExpect(status().isOk());
+			.andExpect(status().isOk())
+			.andDo(
+				document(
+					"products/delete/successful",
 
+					pathParameters(parameterWithName("id").description("삭제할 상품의 번호")),
+
+					pathParameters(
+						parameterWithName("id").description("삭제할 상품의 번호")
+					)
+				)
+			);
+	}
+
+	private OperationRequestPreprocessor getDocumentRequest() {
+		return preprocessRequest(modifyUris().scheme("http").host("localhost").port(8081),
+			prettyPrint());
+	}
+
+	private OperationResponsePreprocessor getDocumentResponse() {
+		return preprocessResponse(prettyPrint());
 	}
 
 	private String toJsonString(Object dto) throws JsonProcessingException {


### PR DESCRIPTION
<!--- The issue this PR addresses (이 PR이 다루는 문제) -->
Fixes #13

**Rest API에 관한 문서화가 없습니다.**
- 문서화를 통해 커뮤니케이션의 비용을 현저히 줄일 수 있습니다.
- 또한 나중에 API수정하는데 오류가 없기 위해서 정확성이 보장 되고, 적합한 표현력을 사용하여 추후에 확장이 가능한 형태가 될 수 있습니다.

**Rest API 문서를 WIKI에 공유할 경우**
- Rest  API 수정시 Rest API 문서에 변경된 코드가 적용되지 않기 때문에 커뮤니케이션애 있어 문제가 발생합니다.

**Rest API의 문서생성을 돕는 도구로는 대표적으로 Swagger와 RestDocs가 존재하지만, RestDocs를 적용하기로 결정하였습니다.**

**우선 Swagger는**
- 실제 코드에 영향을 미치지 않지만 지속해서 추가됨으로써 실제 코드보다 문서 명세에 대한 코드가 더 길어져 전체적인 가독성이 떨어집니다.
- 해당 코드는 주석일뿐 로직에 영향을 미치지 않기 때문에 비즈니스 로직이 변경되더라도 문서를 갱신하지 않아 결국 문서와 코드가 일치하지 않게 됩니다.
- 정상적인 Reponse에 대한 명세 일뿐 상태코드 이외의 값에 대한 정의가 힘듭니다. 이것을 정의하더라도 주석 형태로 정의하게 되어 결국 시간이 지나면 문서와 코드가 일치하지 않게 됩니다.

**이에 반해 Rest Docs는**
- Rest Docs는 테스트 코드 기반으로 문서가 작성되기 때문에 문서와 실제 코드의 일치성이 높고 테스트코드로 문서가 표현되기 때문에 실제 코드에 어떠한 코드 추가도 필요가 없습니다.

<!--- Detailed description of the change/feature (변경 / 기능에 대한 자세한 설명) -->
### 상세 내용
- RestDocs를 적용한 API 문서화 완료
-  [Product API Docs](https://hyungiljung.github.io/)